### PR TITLE
feat: 支持配置无头模式并增强反爬检测

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ pip install -r requirements.txt
     # 是否开启电脑链接转换为手机链接
     PCURL_TO_MOBILE=true
     
+    # 爬虫是否以无头模式运行 (true/false)。遇到滑动验证码时，可设为 false
+    RUN_HEADLESS=true
     ```
 
 2.  **获取登录状态 (重要!)**: 为了让爬虫能够以登录状态访问闲鱼，**必须先运行一次登录脚本**以生成会话状态文件。


### PR DESCRIPTION
引入 `RUN_HEADLESS` 环境变量，允许用户控制 Playwright 浏览器是否以无头模式启动。 默认开启无头模式，用户可设置为 `false` 以应对滑动验证码等反爬挑战。
增加对闲鱼反爬验证弹窗 (baxia-dialog) 的检测，并在触发时提供明确的错误信息和解决方案建议。 更新 `README.md` 文档。