### PR TITLE
feat(日志管理): 添加清空日志功能

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -89,6 +89,18 @@ header h1 {
     border-color: #ff7875;
 }
 
+.control-button.danger-btn {
+    background-color: #ff4d4f;
+    color: white;
+    border-color: #ff4d4f;
+}
+
+.control-button.danger-btn:hover {
+    background-color: #ff7875;
+    border-color: #ff7875;
+    color: white;
+}
+
 
 .container {
     display: flex;
@@ -485,6 +497,12 @@ input:checked + .slider:before {
     border-top: 1px solid #f0f0f0;
     display: flex;
     justify-content: flex-end;
+    gap: 12px;
+}
+
+.log-controls {
+    display: flex;
+    align-items: center;
     gap: 12px;
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -45,12 +45,13 @@ document.addEventListener('DOMContentLoaded', function() {
             <section id="logs-section" class="content-section">
                 <div class="section-header">
                     <h2>运行日志</h2>
-                    <div>
+                    <div class="log-controls">
                         <label>
                             <input type="checkbox" id="auto-refresh-logs-checkbox">
                             自动刷新
                         </label>
                         <button id="refresh-logs-btn" class="control-button">🔄 刷新</button>
+                        <button id="clear-logs-btn" class="control-button danger-btn">🗑️ 清空日志</button>
                     </div>
                 </div>
                 <pre id="log-content-container">正在加载日志...</pre>
@@ -234,6 +235,21 @@ document.addEventListener('DOMContentLoaded', function() {
             return await response.json();
         } catch (error) {
             console.error("无法获取系统状态:", error);
+            return null;
+        }
+    }
+
+    async function clearLogs() {
+        try {
+            const response = await fetch('/api/logs', { method: 'DELETE' });
+            if (!response.ok) {
+                const err = await response.json();
+                throw new Error(err.detail || '清空日志失败');
+            }
+            return await response.json();
+        } catch (error) {
+            console.error("无法清空日志:", error);
+            alert(`错误: ${error.message}`);
             return null;
         }
     }
@@ -425,6 +441,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const logContainer = document.getElementById('log-content-container');
         const refreshBtn = document.getElementById('refresh-logs-btn');
         const autoRefreshCheckbox = document.getElementById('auto-refresh-logs-checkbox');
+        const clearBtn = document.getElementById('clear-logs-btn');
         let currentLogSize = 0;
 
         const updateLogs = async (isFullRefresh = false) => {
@@ -458,6 +475,16 @@ document.addEventListener('DOMContentLoaded', function() {
         };
 
         refreshBtn.addEventListener('click', () => updateLogs(true));
+
+        clearBtn.addEventListener('click', async () => {
+            if (confirm('你确定要清空所有运行日志吗？此操作不可恢复。')) {
+                const result = await clearLogs();
+                if (result) {
+                    await updateLogs(true);
+                    alert('日志已清空。');
+                }
+            }
+        });
 
         autoRefreshCheckbox.addEventListener('change', () => {
             if (autoRefreshCheckbox.checked) {

--- a/web_server.py
+++ b/web_server.py
@@ -308,6 +308,24 @@ async def get_logs(from_pos: int = 0):
         )
 
 
+@app.delete("/api/logs", response_model=dict)
+async def clear_logs():
+    """
+    清空日志文件内容。
+    """
+    log_file_path = os.path.join("logs", "scraper.log")
+    if not os.path.exists(log_file_path):
+        return {"message": "日志文件不存在，无需清空。"}
+
+    try:
+        # 使用 'w' 模式打开文件会清空内容
+        async with aiofiles.open(log_file_path, 'w') as f:
+            await f.write("")
+        return {"message": "日志已成功清空。"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"清空日志文件时出错: {e}")
+
+
 @app.delete("/api/tasks/{task_id}", response_model=dict)
 async def delete_task(task_id: int):
     """


### PR DESCRIPTION
- 新增前端“清空日志”按钮及相关样式。
- 实现前端清空日志的交互逻辑，包括确认提示和刷新日志显示。
- 新增后端 DELETE /api/logs 接口，用于清空 scraper.log 文件内容。