### PR TITLE
修复并发任务图片不显示问题

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,9 @@ STATE_FILE = "xianyu_state.json"
 IMAGE_SAVE_DIR = "images"
 os.makedirs(IMAGE_SAVE_DIR, exist_ok=True)
 
+# 任务隔离的临时图片目录前缀
+TASK_IMAGE_DIR_PREFIX = "task_images_"
+
 # --- API URL Patterns ---
 API_URL_PATTERN = "h5api.m.goofish.com/h5/mtop.taobao.idlemtopsearch.pc.search"
 DETAIL_API_URL_PATTERN = "h5api.m.goofish.com/h5/mtop.taobao.idle.pc.detail"

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -15,6 +15,7 @@ from src.ai_handler import (
     download_all_images,
     get_ai_analysis,
     send_ntfy_notification,
+    cleanup_task_images,
 )
 from src.config import (
     AI_DEBUG_MODE,
@@ -401,7 +402,7 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                             print(f"   -> 开始对商品 #{item_data['商品ID']} 进行实时AI分析...")
                             # 1. Download images
                             image_urls = item_data.get('商品图片列表', [])
-                            downloaded_image_paths = await download_all_images(item_data['商品ID'], image_urls)
+                            downloaded_image_paths = await download_all_images(item_data['商品ID'], image_urls, task_config.get('task_name', 'default'))
 
                             # 2. Get AI analysis
                             ai_analysis_result = None
@@ -479,5 +480,8 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
             if debug_limit:
                 input("按回车键关闭浏览器...")
             await browser.close()
+
+    # 清理任务图片目录
+    cleanup_task_images(task_config.get('task_name', 'default'))
 
     return processed_item_count


### PR DESCRIPTION
修复了当两个以上任务同时执行时，任务结果图片不显示的问题

- 为每个任务创建独立的临时图片目录，防止并发任务间图片文件冲突
- 在任务结束时清理对应的临时图片目录

Fixes #142

Generated with [Claude Code](https://claude.ai/code)