### PR TITLE
Fix task editing row alignment by adding missing run status column

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1231,6 +1231,10 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('tasks-table-container').innerHTML = renderTasksTable(tasks);
         } else if (button.matches('.edit-btn')) {
             const taskData = JSON.parse(row.dataset.task);
+            const isRunning = taskData.is_running === true;
+            const statusBadge = isRunning
+                ? `<span class="status-badge status-running">运行中</span>`
+                : `<span class="status-badge status-stopped">已停止</span>`;
 
             row.classList.add('editing');
             row.innerHTML = `
@@ -1241,6 +1245,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </label>
                 </td>
                 <td><input type="text" value="${taskData.task_name}" data-field="task_name"></td>
+                <td>${statusBadge}</td>
                 <td><input type="text" value="${taskData.keyword}" data-field="keyword"></td>
                 <td>
                     <input type="text" value="${taskData.min_price || ''}" placeholder="不限" data-field="min_price" style="width: 60px;"> -


### PR DESCRIPTION
This PR fixes the row misalignment issue when clicking the edit button in the task management page. The "运行状态" (run status) column was missing from the edit view, causing all subsequent columns to shift left.

Changes:
- Added the run status badge to the edit row structure
- Ensured column alignment between normal and edit views

Fixes #228

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: rainsfly <dingyufei615@users.noreply.github.com>