### PR TITLE
feat: 在 web 管理界面添加 Telegram 机器人配置功能

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -484,6 +484,18 @@ document.addEventListener('DOMContentLoaded', function() {
                 </div>
                 
                 <div class="form-group">
+                    <label for="telegram-bot-token">Telegram Bot Token</label>
+                    <input type="text" id="telegram-bot-token" name="TELEGRAM_BOT_TOKEN" value="${settings.TELEGRAM_BOT_TOKEN || ''}" placeholder="例如: 1234567890:ABCdefGHIjklMNOpqrsTUVwxyz123456789">
+                    <p class="form-hint">Telegram 机器人的 Token，从 @BotFather 获取</p>
+                </div>
+                
+                <div class="form-group">
+                    <label for="telegram-chat-id">Telegram Chat ID</label>
+                    <input type="text" id="telegram-chat-id" name="TELEGRAM_CHAT_ID" value="${settings.TELEGRAM_CHAT_ID || ''}" placeholder="例如: 123456789">
+                    <p class="form-hint">Telegram Chat ID，从 @userinfobot 获取</p>
+                </div>
+                
+                <div class="form-group">
                     <label for="webhook-url">通用 Webhook URL</label>
                     <input type="text" id="webhook-url" name="WEBHOOK_URL" value="${settings.WEBHOOK_URL || ''}" placeholder="例如: https://your-webhook-url.com/endpoint">
                     <p class="form-hint">通用 Webhook 的 URL 地址</p>

--- a/web_server.py
+++ b/web_server.py
@@ -79,6 +79,8 @@ class NotificationSettings(BaseModel):
     GOTIFY_TOKEN: Optional[str] = None
     BARK_URL: Optional[str] = None
     WX_BOT_URL: Optional[str] = None
+    TELEGRAM_BOT_TOKEN: Optional[str] = None
+    TELEGRAM_CHAT_ID: Optional[str] = None
     WEBHOOK_URL: Optional[str] = None
     WEBHOOK_METHOD: Optional[str] = "POST"
     WEBHOOK_HEADERS: Optional[str] = None
@@ -129,6 +131,8 @@ def load_notification_settings():
         "GOTIFY_TOKEN": config.get("GOTIFY_TOKEN", ""),
         "BARK_URL": config.get("BARK_URL", ""),
         "WX_BOT_URL": config.get("WX_BOT_URL", ""),
+        "TELEGRAM_BOT_TOKEN": config.get("TELEGRAM_BOT_TOKEN", ""),
+        "TELEGRAM_CHAT_ID": config.get("TELEGRAM_CHAT_ID", ""),
         "WEBHOOK_URL": config.get("WEBHOOK_URL", ""),
         "WEBHOOK_METHOD": config.get("WEBHOOK_METHOD", "POST"),
         "WEBHOOK_HEADERS": config.get("WEBHOOK_HEADERS", ""),
@@ -152,8 +156,9 @@ def save_notification_settings(settings: dict):
     # Update or add notification settings
     setting_keys = [
         "NTFY_TOPIC_URL", "GOTIFY_URL", "GOTIFY_TOKEN", "BARK_URL",
-        "WX_BOT_URL", "WEBHOOK_URL", "WEBHOOK_METHOD", "WEBHOOK_HEADERS",
-        "WEBHOOK_CONTENT_TYPE", "WEBHOOK_QUERY_PARAMETERS", "WEBHOOK_BODY", "PCURL_TO_MOBILE"
+        "WX_BOT_URL", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID", "WEBHOOK_URL", 
+        "WEBHOOK_METHOD", "WEBHOOK_HEADERS", "WEBHOOK_CONTENT_TYPE", "WEBHOOK_QUERY_PARAMETERS", 
+        "WEBHOOK_BODY", "PCURL_TO_MOBILE"
     ]
 
     # Create a dictionary of existing settings


### PR DESCRIPTION
## 摘要
在 web 管理界面中添加了 Telegram 机器人配置功能，用户可以通过界面直接配置 Telegram 推送通知。

## 更改内容
- 在前端通知设置表单中添加 Telegram Bot Token 配置项
- 添加 Telegram Chat ID 配置项
- 更新后端 NotificationSettings 模型包含 Telegram 字段
- 更新配置读写函数处理 Telegram 配置
- 在配置表单中添加详细的配置说明和示例

resolves #239

Generated with [Claude Code](https://claude.ai/code)