### PR TITLE
更新 README.md 中的 git clone 链接为 Usagi-org 组织地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 克隆本项目到本地:
 
 ```bash
-git clone https://github.com/dingyufei615/ai-goofish-monitor
+git clone https://github.com/Usagi-org/ai-goofish-monitor
 cd ai-goofish-monitor
 ```
 
@@ -149,7 +149,7 @@ python web_server.py
 2. **克隆项目并配置**:
 
     ```bash
-    git clone https://github.com/dingyufei615/ai-goofish-monitor
+    git clone https://github.com/Usagi-org/ai-goofish-monitor
     cd ai-goofish-monitor
     ```
 


### PR DESCRIPTION
根据 issue #259 的要求，更新了 README.md 文件中的 git clone 链接：nn- 将两处 git clone 链接从 https://github.com/dingyufei615/ai-goofish-monitor 更新为 https://github.com/Usagi-org/ai-goofish-monitornn此更改确保用户使用正确的组织地址克隆项目。nnGenerated with [Claude Code](https://claude.ai/code)