### PR TITLE
chore(ci): 更新Docker镜像仓库地址和CI配置

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,7 +35,12 @@ jobs:
       
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-      
+
+    - name: Set lowercase repository owner
+      env:
+        REPO_OWNER: ${{ github.repository_owner }}
+      run: echo "REPO_OWNER_LOWER=$(echo $REPO_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -51,5 +56,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
-          ghcr.io/${{ github.repository_owner }}/ai-goofish:latest
-          ghcr.io/${{ github.repository_owner }}/ai-goofish:${{ github.sha }}
+          ghcr.io/${{ env.REPO_OWNER_LOWER }}/ai-goofish:latest
+          ghcr.io/${{ env.REPO_OWNER_LOWER }}/ai-goofish:${{ github.sha }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    image: ghcr.io/dingyufei615/ai-goofish:latest
+    image: ghcr.io/usagi-org/ai-goofish:latest
     container_name: ai-goofish-monitor-app
     pull_policy: always
     ports:


### PR DESCRIPTION
- 将Docker镜像仓库从 dingyufei615 迁移到 usagi-org
- 在CI工作流中添加小写仓库所有者环境变量处理
- 更新Docker镜像推送标签使用小写仓库所有者名称
- 修复仓库所有者名称大小写敏感问题