### PR TITLE
feat(build): 添加桌面应用构建工作流和打包功能

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,122 @@
+name: Desktop Build (Win + macOS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_name:
+        description: "building go go go"
+        required: false
+        type: string
+  push:
+    tags:
+      - "v*"
+
+env:
+  PYTHONIOENCODING: utf-8
+  PLAYWRIGHT_BROWSERS_PATH: 0
+  APP_NAME: ${{ github.event.inputs.build_name || 'XianyuMonitor' }}
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: web-ui/package-lock.json
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pyinstaller
+
+      - name: Install Playwright chromium
+        run: python -m playwright install chromium
+
+      - name: Build frontend
+        working-directory: web-ui
+        run: |
+          npm ci
+          npm run build
+
+      - name: Copy frontend dist to backend
+        shell: pwsh
+        run: |
+          Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue
+          Copy-Item -Recurse -Force web-ui/dist ./dist
+
+      - name: Package desktop app (Windows)
+        run: python scripts/package_desktop.py --name "${{ env.APP_NAME }}"
+
+      - name: Archive artifact
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path packaged | Out-Null
+          Compress-Archive -Path "dist/${{ env.APP_NAME }}.exe" -DestinationPath "packaged/${{ env.APP_NAME }}-windows.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-windows
+          path: packaged/${{ env.APP_NAME }}-windows.zip
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: web-ui/package-lock.json
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pyinstaller
+
+      - name: Install Playwright chromium
+        run: python -m playwright install chromium
+
+      - name: Build frontend
+        working-directory: web-ui
+        run: |
+          npm ci
+          npm run build
+
+      - name: Copy frontend dist to backend
+        run: |
+          rm -rf dist
+          cp -r web-ui/dist ./dist
+
+      - name: Package desktop app (macOS)
+        run: python scripts/package_desktop.py --name "${{ env.APP_NAME }}"
+
+      - name: Archive artifact
+        run: |
+          mkdir -p packaged
+          tar -czf "packaged/${{ env.APP_NAME }}-macos.tar.gz" -C dist "${{ env.APP_NAME }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-macos
+          path: packaged/${{ env.APP_NAME }}-macos.tar.gz

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -1,0 +1,46 @@
+"""
+桌面启动入口
+使用 PyInstaller 打包后作为单一可执行文件的入口，自动启动 FastAPI 服务并打开浏览器。
+"""
+import os
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
+import uvicorn
+
+# PyInstaller 运行时资源目录：_MEIPASS；未打包时则为当前文件所在目录
+BASE_DIR = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent))
+
+
+def _prepare_environment() -> None:
+    """确保工作目录和模块路径正确"""
+    os.chdir(BASE_DIR)
+    if str(BASE_DIR) not in sys.path:
+        sys.path.insert(0, str(BASE_DIR))
+
+
+def run_app() -> None:
+    """启动 FastAPI 应用并自动打开浏览器"""
+    _prepare_environment()
+
+    from src.app import app
+    from src.infrastructure.config.settings import settings
+
+    # 先尝试打开浏览器，稍等服务起来
+    url = f"http://127.0.0.1:{settings.server_port}"
+    webbrowser.open(url)
+    time.sleep(0.5)
+
+    uvicorn.run(
+        app,
+        host="127.0.0.1",
+        port=settings.server_port,
+        log_level="info",
+        reload=False,
+    )
+
+
+if __name__ == "__main__":
+    run_app()

--- a/scripts/package_desktop.py
+++ b/scripts/package_desktop.py
@@ -1,0 +1,79 @@
+"""
+跨平台打包脚本
+使用 PyInstaller 将桌面启动入口 desktop_launcher.py 打成独立可执行文件。
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = ROOT / "desktop_launcher.py"
+DIST_DIR = ROOT / "dist"
+DEFAULT_NAME = "XianyuMonitor"
+
+
+def ensure_frontend_built() -> None:
+    """保证前端产物 dist 存在"""
+    dist_path = ROOT / "dist"
+    web_dist = ROOT / "web-ui" / "dist"
+
+    if dist_path.exists():
+        return
+
+    if not web_dist.exists():
+        raise RuntimeError("未找到 dist，请先在 web-ui 目录运行 npm run build")
+
+    shutil.copytree(web_dist, dist_path)
+
+
+def build(args: argparse.Namespace) -> None:
+    """调用 PyInstaller 进行打包"""
+    ensure_frontend_built()
+
+    name = args.name or DEFAULT_NAME
+    pyinstaller_args = [
+        "--name",
+        name,
+        "--onefile",
+        "--noconfirm",
+        "--clean",
+        "--add-data",
+        f"{ROOT / 'dist'}{os.pathsep}dist",
+        "--add-data",
+        f"{ROOT / 'static'}{os.pathsep}static",
+        "--add-data",
+        f"{ROOT / 'prompts'}{os.pathsep}prompts",
+        "--add-data",
+        f"{ROOT / 'config.json'}{os.pathsep}.",
+    ]
+
+    # .env 可选
+    env_file = ROOT / ".env"
+    if env_file.exists():
+        pyinstaller_args.extend(["--add-data", f"{env_file}{os.pathsep}."])
+
+    # Playwright 资源自动收集
+    pyinstaller_args.extend(["--collect-all", "playwright"])
+
+    # 指定入口
+    pyinstaller_args.append(str(LAUNCHER))
+
+    print("运行 PyInstaller 参数:", " ".join(pyinstaller_args))
+    subprocess.check_call([sys.executable, "-m", "PyInstaller", *pyinstaller_args])
+
+    print(f"完成，产物位于 {ROOT / 'dist'}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PyInstaller 桌面打包脚本")
+    parser.add_argument("--name", help="生成的可执行文件名，默认 XianyuMonitor")
+    args = parser.parse_args()
+    build(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- 配置 GitHub Actions 工作流实现 Windows 和 macOS 平台自动构建
- 创建 desktop_launcher.py 作为桌面应用启动入口文件
- 实现 scripts/package_desktop.py 跨平台打包脚本
- 集成 PyInstaller 实现前端和后端代码打包为单一可执行文件
- 添加构建产物压缩和上传到 artifacts 的完整流程