### PR TITLE
windows本地启动登录及创建任务时bug修复

### DIFF
--- a/web-ui/src/views/TasksView.vue
+++ b/web-ui/src/views/TasksView.vue
@@ -87,6 +87,8 @@ async function handleCreateTask(data: TaskGenerateRequest) {
   try {
     await createTask(data)
     isCreateDialogOpen.value = false
+    // 创建成功后刷新页面
+    window.location.reload()
   }
   catch (e) {
     toast({

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         target: 'http://127.0.0.1:8000',
         changeOrigin: true,
       },
+      '/auth': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+      },
       '/ws': {
         target: 'ws://127.0.0.1:8000',
         ws: true,


### PR DESCRIPTION
1.修复问题web-ui开发代理只转发了 /api 和 /ws，但登录请求走的是 /auth/status
2.修复创建任务成功后弹窗不能自动关闭问题（创建成功响应后刷新页面）