### PR TITLE
fix: pause tasks after repeated failures (daily reminder + auto-recover)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,14 @@ WEBHOOK_CONTENT_TYPE="JSON"
 WEBHOOK_QUERY_PARAMETERS='{"title":"{{title}}","content":"{{content}}"}'
 # POST请求的请求体 (JSON格式, 支持 {{title}}, {{content}} 占位符)
 WEBHOOK_BODY='{"title":"{{title}}","content":"{{content}}"}'
+
+
+# --- 任务失败保护(可选) ---
+# 当任务持续失败(例如 cookies 失效导致跳转登录页/风控)时:
+# - 连续失败达到阈值后暂停任务一段时间，避免无限重试
+# - 失败通知最多每日 1 次，直到修复(更新登录态/cookies)自动恢复
+TASK_FAILURE_THRESHOLD=3
+# 默认 86400 (24h)
+TASK_FAILURE_PAUSE_SECONDS=86400
+# 状态文件路径(默认 logs/task-failure-guard.json)
+TASK_FAILURE_GUARD_PATH=

--- a/src/failure_guard.py
+++ b/src/failure_guard.py
@@ -1,0 +1,357 @@
+"""Task-level failure circuit breaker.
+
+目标:
+- 当登录态失效/风控导致任务持续失败时，避免无限重试、避免高频请求。
+- 失败达到阈值后暂停任务一段时间。
+- 暂停期间最多每天通知一次，直到用户更新 cookies / 登录态文件后自动恢复。
+
+说明:
+- 仅使用标准库，既可被 API 主进程使用，也可被爬虫子进程使用。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+
+try:
+    from zoneinfo import ZoneInfo  # py3.9+
+
+    def _load_tz(name: str):
+        return ZoneInfo(name)
+
+
+except Exception:  # pragma: no cover
+
+    def _load_tz(name: str):
+        return None
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _now(tz_name: str, now: Optional[datetime] = None) -> datetime:
+    if now is not None:
+        return now
+    tz = _load_tz(tz_name)
+    if tz is None:
+        return datetime.now()
+    return datetime.now(tz)
+
+
+def _today_str(tz_name: str, now: Optional[datetime] = None) -> str:
+    return _now(tz_name, now=now).date().isoformat()
+
+
+def _dt_to_str(dt: Optional[datetime]) -> Optional[str]:
+    if dt is None:
+        return None
+    return dt.isoformat()
+
+
+def _str_to_dt(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _get_mtime(path: Optional[str]) -> Optional[float]:
+    if not path:
+        return None
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def _cookie_changed(
+    cookie_path: Optional[str], previous_mtime: Optional[float]
+) -> bool:
+    if not cookie_path:
+        return False
+    current = _get_mtime(cookie_path)
+    if current is None or previous_mtime is None:
+        return False
+    return current > (previous_mtime + 1e-6)
+
+
+class _FileLock:
+    def __init__(self, fh):
+        self._fh = fh
+
+    def __enter__(self):
+        try:
+            import fcntl
+
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
+        except Exception:
+            pass
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            import fcntl
+
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        return False
+
+
+def _ensure_parent_dir(path: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+
+def _read_json_file(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        # 文件损坏时保留现场，避免无限解析失败。
+        try:
+            ts = str(int(time.time()))
+            os.replace(path, f"{path}.corrupt.{ts}")
+        except Exception:
+            pass
+        return {}
+
+
+def _atomic_write_json(path: str, data: dict) -> None:
+    _ensure_parent_dir(path)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+@dataclass(frozen=True)
+class SkipDecision:
+    skip: bool
+    should_notify: bool
+    reason: str
+    paused_until: Optional[datetime]
+    consecutive_failures: int
+
+
+class FailureGuard:
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        *,
+        threshold: Optional[int] = None,
+        pause_seconds: Optional[int] = None,
+        tz_name: Optional[str] = None,
+    ):
+        self.path = (
+            path
+            or os.getenv("TASK_FAILURE_GUARD_PATH")
+            or "logs/task-failure-guard.json"
+        )
+        self.threshold = max(
+            1, threshold or _as_int(os.getenv("TASK_FAILURE_THRESHOLD"), 3)
+        )
+        self.pause_seconds = max(
+            60,
+            pause_seconds
+            or _as_int(os.getenv("TASK_FAILURE_PAUSE_SECONDS"), 24 * 60 * 60),
+        )
+        self.tz_name = tz_name or os.getenv("TASK_FAILURE_TZ") or "Asia/Shanghai"
+
+    def _load(self) -> dict:
+        data = _read_json_file(self.path)
+        if "tasks" not in data or not isinstance(data.get("tasks"), dict):
+            data = {"version": 1, "tasks": {}}
+        data.setdefault("version", 1)
+        return data
+
+    def _save(self, data: dict) -> None:
+        _atomic_write_json(self.path, data)
+
+    def _update_task(self, task_key: str, updater) -> dict:
+        _ensure_parent_dir(self.path)
+        with open(self.path, "a+", encoding="utf-8") as fh:
+            with _FileLock(fh):
+                fh.seek(0)
+                data = self._load()
+                tasks = data.setdefault("tasks", {})
+                entry = tasks.get(task_key) or {}
+                if not isinstance(entry, dict):
+                    entry = {}
+                entry = updater(entry) or entry
+                tasks[task_key] = entry
+                self._save(data)
+                return entry
+
+    def record_success(self, task_key: str, *, now: Optional[datetime] = None) -> None:
+        def _reset(_: dict) -> dict:
+            current = _now(self.tz_name, now=now)
+            return {
+                "consecutive_failures": 0,
+                "paused_until": None,
+                "last_notified_date": None,
+                "last_failure_reason": None,
+                "last_failure_at": None,
+                "last_success_at": _dt_to_str(current),
+                "cookie_path": None,
+                "cookie_mtime": None,
+            }
+
+        self._update_task(task_key, _reset)
+
+    def should_skip_start(
+        self,
+        task_key: str,
+        *,
+        cookie_path: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> SkipDecision:
+        current = _now(self.tz_name, now=now)
+        today = _today_str(self.tz_name, now=current)
+
+        data = self._load()
+        entry = (data.get("tasks") or {}).get(task_key) or {}
+        if not isinstance(entry, dict):
+            entry = {}
+
+        paused_until = _str_to_dt(entry.get("paused_until"))
+        consecutive = _as_int(entry.get("consecutive_failures"), 0)
+        last_reason = (entry.get("last_failure_reason") or "").strip() or "未知错误"
+        last_notified_date = entry.get("last_notified_date")
+
+        previous_cookie_mtime = entry.get("cookie_mtime")
+        if cookie_path and previous_cookie_mtime is not None:
+            try:
+                previous_cookie_mtime = float(previous_cookie_mtime)
+            except (TypeError, ValueError):
+                previous_cookie_mtime = None
+
+        if (
+            paused_until
+            and paused_until > current
+            and cookie_path
+            and _cookie_changed(cookie_path, previous_cookie_mtime)
+        ):
+            # cookies / 登录态更新 => 自动恢复
+            self.record_success(task_key, now=current)
+            return SkipDecision(
+                skip=False,
+                should_notify=False,
+                reason="cookie_updated",
+                paused_until=None,
+                consecutive_failures=0,
+            )
+
+        if paused_until and current < paused_until:
+            should_notify = last_notified_date != today
+
+            if should_notify:
+
+                def _touch(e: dict) -> dict:
+                    e = dict(e or {})
+                    e["last_notified_date"] = today
+                    return e
+
+                self._update_task(task_key, _touch)
+
+            return SkipDecision(
+                skip=True,
+                should_notify=should_notify,
+                reason=last_reason,
+                paused_until=paused_until,
+                consecutive_failures=consecutive,
+            )
+
+        return SkipDecision(
+            skip=False,
+            should_notify=False,
+            reason="not_paused",
+            paused_until=None,
+            consecutive_failures=consecutive,
+        )
+
+    def record_failure(
+        self,
+        task_key: str,
+        reason: str,
+        *,
+        cookie_path: Optional[str] = None,
+        min_failures_to_pause: Optional[int] = None,
+        now: Optional[datetime] = None,
+    ) -> dict:
+        current = _now(self.tz_name, now=now)
+        today = _today_str(self.tz_name, now=current)
+        cookie_mtime = _get_mtime(cookie_path)
+
+        effective_threshold = max(1, int(min_failures_to_pause or self.threshold))
+
+        result = {
+            "should_notify": False,
+            "opened_circuit": False,
+            "paused_until": None,
+            "consecutive_failures": 0,
+        }
+
+        def _apply(entry: dict) -> dict:
+            entry = dict(entry or {})
+            previous_paused_until = _str_to_dt(entry.get("paused_until"))
+            was_paused = bool(previous_paused_until and current < previous_paused_until)
+
+            prev_mtime = entry.get("cookie_mtime")
+            try:
+                prev_mtime = float(prev_mtime) if prev_mtime is not None else None
+            except (TypeError, ValueError):
+                prev_mtime = None
+
+            if cookie_path and _cookie_changed(cookie_path, prev_mtime):
+                entry["consecutive_failures"] = 0
+                entry["paused_until"] = None
+                entry["last_notified_date"] = None
+
+            consecutive = _as_int(entry.get("consecutive_failures"), 0) + 1
+            entry["consecutive_failures"] = consecutive
+            entry["last_failure_reason"] = (reason or "未知错误")[:1000]
+            entry["last_failure_at"] = _dt_to_str(current)
+            if cookie_path:
+                entry["cookie_path"] = cookie_path
+                if cookie_mtime is not None:
+                    entry["cookie_mtime"] = cookie_mtime
+
+            opened = False
+            if consecutive >= effective_threshold:
+                paused_until = current + timedelta(seconds=self.pause_seconds)
+                entry["paused_until"] = _dt_to_str(paused_until)
+                opened = not was_paused
+
+                if entry.get("last_notified_date") != today:
+                    entry["last_notified_date"] = today
+                    result["should_notify"] = True
+
+                result["paused_until"] = paused_until
+            else:
+                entry["paused_until"] = None
+
+            result["opened_circuit"] = opened
+            result["consecutive_failures"] = consecutive
+            return entry
+
+        self._update_task(task_key, _apply)
+        return result

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -44,10 +44,87 @@ from src.utils import (
 )
 from src.rotation import RotationPool, load_state_files, parse_proxy_pool, RotationItem
 from src.keyword_rule_engine import build_search_text, evaluate_keyword_rules
+from src.failure_guard import FailureGuard
 
 
 class RiskControlError(Exception):
     pass
+
+
+class LoginRequiredError(Exception):
+    """Raised when Goofish redirects to the passport/mini_login flow."""
+
+
+FAILURE_GUARD = FailureGuard()
+
+
+def _is_login_url(url: str) -> bool:
+    if not url:
+        return False
+    lowered = url.lower()
+    return "passport.goofish.com" in lowered or "mini_login" in lowered
+
+
+def _format_failure_reason(reason: str, limit: int = 500) -> str:
+    if not reason:
+        return "未知错误"
+    cleaned = " ".join(str(reason).split())
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: limit - 3] + "..."
+
+
+async def _notify_task_failure(
+    task_config: dict, reason: str, *, cookie_path: Optional[str]
+) -> None:
+    task_name = task_config.get("task_name", "未命名任务")
+    keyword = task_config.get("keyword", "")
+    formatted_reason = _format_failure_reason(reason)
+
+    # Some failures are deterministic misconfiguration and should pause/notify immediately.
+    pause_immediately = any(
+        marker in formatted_reason
+        for marker in (
+            "未找到可用的代理地址",
+            "未找到可用的登录状态文件",
+        )
+    )
+
+    guard_result = FAILURE_GUARD.record_failure(
+        task_name,
+        formatted_reason,
+        cookie_path=cookie_path,
+        min_failures_to_pause=1 if pause_immediately else None,
+    )
+
+    if not guard_result.get("should_notify"):
+        print(
+            f"[FailureGuard] 任务 '{task_name}' 失败计数 {guard_result.get('consecutive_failures')}/{FAILURE_GUARD.threshold}，暂不通知。"
+        )
+        return
+
+    paused_until = guard_result.get("paused_until")
+    paused_until_str = (
+        paused_until.strftime("%Y-%m-%d %H:%M:%S") if paused_until else "N/A"
+    )
+
+    product_data = {
+        "商品标题": f"[任务异常] {task_name}",
+        "当前售价": "N/A",
+        "商品链接": "#",
+    }
+    notify_reason = (
+        f"任务运行失败(已连续 {guard_result.get('consecutive_failures')}/{FAILURE_GUARD.threshold} 次): {formatted_reason}"
+        f"\n任务: {task_name}"
+        f"\n关键词: {keyword or 'N/A'}"
+        f"\n已自动暂停重试，暂停到: {paused_until_str}"
+        f"\n修复后(更新登录态/cookies文件)将自动恢复。"
+    )
+
+    try:
+        await send_ntfy_notification(product_data, notify_reason)
+    except Exception as e:
+        print(f"发送任务异常通知失败: {e}")
 
 
 def _as_bool(value, default: bool = False) -> bool:
@@ -71,17 +148,40 @@ def _get_rotation_settings(task_config: dict) -> dict:
     account_cfg = task_config.get("account_rotation") or {}
     proxy_cfg = task_config.get("proxy_rotation") or {}
 
-    account_enabled = _as_bool(account_cfg.get("enabled"), _as_bool(os.getenv("ACCOUNT_ROTATION_ENABLED"), False))
-    account_mode = (account_cfg.get("mode") or os.getenv("ACCOUNT_ROTATION_MODE", "per_task")).lower()
-    account_state_dir = account_cfg.get("state_dir") or os.getenv("ACCOUNT_STATE_DIR", "state")
-    account_retry_limit = _as_int(account_cfg.get("retry_limit"), _as_int(os.getenv("ACCOUNT_ROTATION_RETRY_LIMIT"), 2))
-    account_blacklist_ttl = _as_int(account_cfg.get("blacklist_ttl_sec"), _as_int(os.getenv("ACCOUNT_BLACKLIST_TTL"), 300))
+    account_enabled = _as_bool(
+        account_cfg.get("enabled"),
+        _as_bool(os.getenv("ACCOUNT_ROTATION_ENABLED"), False),
+    )
+    account_mode = (
+        account_cfg.get("mode") or os.getenv("ACCOUNT_ROTATION_MODE", "per_task")
+    ).lower()
+    account_state_dir = account_cfg.get("state_dir") or os.getenv(
+        "ACCOUNT_STATE_DIR", "state"
+    )
+    account_retry_limit = _as_int(
+        account_cfg.get("retry_limit"),
+        _as_int(os.getenv("ACCOUNT_ROTATION_RETRY_LIMIT"), 2),
+    )
+    account_blacklist_ttl = _as_int(
+        account_cfg.get("blacklist_ttl_sec"),
+        _as_int(os.getenv("ACCOUNT_BLACKLIST_TTL"), 300),
+    )
 
-    proxy_enabled = _as_bool(proxy_cfg.get("enabled"), _as_bool(os.getenv("PROXY_ROTATION_ENABLED"), False))
-    proxy_mode = (proxy_cfg.get("mode") or os.getenv("PROXY_ROTATION_MODE", "per_task")).lower()
+    proxy_enabled = _as_bool(
+        proxy_cfg.get("enabled"), _as_bool(os.getenv("PROXY_ROTATION_ENABLED"), False)
+    )
+    proxy_mode = (
+        proxy_cfg.get("mode") or os.getenv("PROXY_ROTATION_MODE", "per_task")
+    ).lower()
     proxy_pool = proxy_cfg.get("proxy_pool") or os.getenv("PROXY_POOL", "")
-    proxy_retry_limit = _as_int(proxy_cfg.get("retry_limit"), _as_int(os.getenv("PROXY_ROTATION_RETRY_LIMIT"), 2))
-    proxy_blacklist_ttl = _as_int(proxy_cfg.get("blacklist_ttl_sec"), _as_int(os.getenv("PROXY_BLACKLIST_TTL"), 300))
+    proxy_retry_limit = _as_int(
+        proxy_cfg.get("retry_limit"),
+        _as_int(os.getenv("PROXY_ROTATION_RETRY_LIMIT"), 2),
+    )
+    proxy_blacklist_ttl = _as_int(
+        proxy_cfg.get("blacklist_ttl_sec"),
+        _as_int(os.getenv("PROXY_BLACKLIST_TTL"), 300),
+    )
 
     return {
         "account_enabled": account_enabled,
@@ -136,7 +236,11 @@ def _build_context_overrides(snapshot: dict) -> dict:
 
     overrides = {}
 
-    ua = headers.get("User-Agent") or headers.get("user-agent") or navigator.get("userAgent")
+    ua = (
+        headers.get("User-Agent")
+        or headers.get("user-agent")
+        or navigator.get("userAgent")
+    )
     if ua:
         overrides["user_agent"] = ua
 
@@ -201,20 +305,24 @@ async def scrape_user_profile(context, user_id: str) -> dict:
 
     async def handle_response(response: Response):
         # 捕获头部摘要API
-        if "mtop.idle.web.user.page.head" in response.url and not head_api_future.done():
+        if (
+            "mtop.idle.web.user.page.head" in response.url
+            and not head_api_future.done()
+        ):
             try:
                 head_api_future.set_result(await response.json())
                 print(f"      [API捕获] 用户头部信息... 成功")
             except Exception as e:
-                if not head_api_future.done(): head_api_future.set_exception(e)
+                if not head_api_future.done():
+                    head_api_future.set_exception(e)
 
         # 捕获商品列表API
         elif "mtop.idle.web.xyh.item.list" in response.url:
             try:
                 data = await response.json()
-                all_items.extend(data.get('data', {}).get('cardList', []))
+                all_items.extend(data.get("data", {}).get("cardList", []))
                 print(f"      [API捕获] 商品列表... 当前已捕获 {len(all_items)} 件")
-                if not data.get('data', {}).get('nextPage', True):
+                if not data.get("data", {}).get("nextPage", True):
                     stop_item_scrolling.set()
             except Exception as e:
                 stop_item_scrolling.set()
@@ -223,9 +331,9 @@ async def scrape_user_profile(context, user_id: str) -> dict:
         elif "mtop.idle.web.trade.rate.list" in response.url:
             try:
                 data = await response.json()
-                all_ratings.extend(data.get('data', {}).get('cardList', []))
+                all_ratings.extend(data.get("data", {}).get("cardList", []))
                 print(f"      [API捕获] 评价列表... 当前已捕获 {len(all_ratings)} 条")
-                if not data.get('data', {}).get('nextPage', True):
+                if not data.get("data", {}).get("nextPage", True):
                     stop_rating_scrolling.set()
             except Exception as e:
                 stop_rating_scrolling.set()
@@ -234,15 +342,19 @@ async def scrape_user_profile(context, user_id: str) -> dict:
 
     try:
         # --- 任务1: 导航并采集头部信息 ---
-        await page.goto(f"https://www.goofish.com/personal?userId={user_id}", wait_until="domcontentloaded", timeout=20000)
+        await page.goto(
+            f"https://www.goofish.com/personal?userId={user_id}",
+            wait_until="domcontentloaded",
+            timeout=20000,
+        )
         head_data = await asyncio.wait_for(head_api_future, timeout=15)
         profile_data = await parse_user_head_data(head_data)
 
         # --- 任务2: 滚动加载所有商品 (默认页面) ---
         print("      [采集阶段] 开始采集该用户的商品列表...")
-        await random_sleep(2, 4) # 等待第一页商品API完成
+        await random_sleep(2, 4)  # 等待第一页商品API完成
         while not stop_item_scrolling.is_set():
-            await page.evaluate('window.scrollTo(0, document.body.scrollHeight)')
+            await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
             try:
                 await asyncio.wait_for(stop_item_scrolling.wait(), timeout=8)
             except asyncio.TimeoutError:
@@ -255,17 +367,17 @@ async def scrape_user_profile(context, user_id: str) -> dict:
         rating_tab_locator = page.locator("//div[text()='信用及评价']/ancestor::li")
         if await rating_tab_locator.count() > 0:
             await rating_tab_locator.click()
-            await random_sleep(3, 5) # 等待第一页评价API完成
+            await random_sleep(3, 5)  # 等待第一页评价API完成
 
             while not stop_rating_scrolling.is_set():
-                await page.evaluate('window.scrollTo(0, document.body.scrollHeight)')
+                await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
                 try:
                     await asyncio.wait_for(stop_rating_scrolling.wait(), timeout=8)
                 except asyncio.TimeoutError:
                     print("      [滚动超时] 评价列表可能已加载完毕。")
                     break
 
-            profile_data['卖家收到的评价列表'] = await parse_ratings_data(all_ratings)
+            profile_data["卖家收到的评价列表"] = await parse_ratings_data(all_ratings)
             reputation_stats = await calculate_reputation_from_ratings(all_ratings)
             profile_data.update(reputation_stats)
         else:
@@ -286,33 +398,35 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
     【核心执行器】
     根据单个任务配置，异步爬取闲鱼商品数据，并对每个新发现的商品进行实时的、独立的AI分析和通知。
     """
-    keyword = task_config['keyword']
-    max_pages = task_config.get('max_pages', 1)
-    personal_only = task_config.get('personal_only', False)
-    min_price = task_config.get('min_price')
-    max_price = task_config.get('max_price')
-    ai_prompt_text = task_config.get('ai_prompt_text', '')
+    keyword = task_config["keyword"]
+    max_pages = task_config.get("max_pages", 1)
+    personal_only = task_config.get("personal_only", False)
+    min_price = task_config.get("min_price")
+    max_price = task_config.get("max_price")
+    ai_prompt_text = task_config.get("ai_prompt_text", "")
     decision_mode = str(task_config.get("decision_mode", "ai")).strip().lower()
     if decision_mode not in {"ai", "keyword"}:
         decision_mode = "ai"
     keyword_rules = task_config.get("keyword_rules") or []
-    free_shipping = task_config.get('free_shipping', False)
-    raw_new_publish = task_config.get('new_publish_option') or ''
+    free_shipping = task_config.get("free_shipping", False)
+    raw_new_publish = task_config.get("new_publish_option") or ""
     new_publish_option = raw_new_publish.strip()
-    if new_publish_option == '__none__':
-        new_publish_option = ''
-    region_filter = (task_config.get('region') or '').strip()
+    if new_publish_option == "__none__":
+        new_publish_option = ""
+    region_filter = (task_config.get("region") or "").strip()
 
     processed_links = set()
-    output_filename = os.path.join("jsonl", f"{keyword.replace(' ', '_')}_full_data.jsonl")
+    output_filename = os.path.join(
+        "jsonl", f"{keyword.replace(' ', '_')}_full_data.jsonl"
+    )
     if os.path.exists(output_filename):
         print(f"LOG: 发现已存在文件 {output_filename}，正在加载历史记录以去重...")
         try:
-            with open(output_filename, 'r', encoding='utf-8') as f:
+            with open(output_filename, "r", encoding="utf-8") as f:
                 for line in f:
                     try:
                         record = json.loads(line)
-                        link = record.get('商品信息', {}).get('商品链接', '')
+                        link = record.get("商品信息", {}).get("商品链接", "")
                         if link:
                             processed_links.add(get_link_unique_key(link))
                     except json.JSONDecodeError:
@@ -335,8 +449,14 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
     if not forced_account and not os.path.exists(STATE_FILE) and account_items:
         rotation_settings["account_enabled"] = True
 
-    account_pool = RotationPool(account_items, rotation_settings["account_blacklist_ttl"], "account")
-    proxy_pool = RotationPool(parse_proxy_pool(rotation_settings["proxy_pool"]), rotation_settings["proxy_blacklist_ttl"], "proxy")
+    account_pool = RotationPool(
+        account_items, rotation_settings["account_blacklist_ttl"], "account"
+    )
+    proxy_pool = RotationPool(
+        parse_proxy_pool(rotation_settings["proxy_pool"]),
+        rotation_settings["proxy_blacklist_ttl"],
+        "proxy",
+    )
 
     selected_account: Optional[RotationItem] = None
     selected_proxy: Optional[RotationItem] = None
@@ -349,7 +469,11 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
             if os.path.exists(STATE_FILE):
                 return RotationItem(value=STATE_FILE)
             return None
-        if rotation_settings["account_mode"] == "per_task" and selected_account and not force_new:
+        if (
+            rotation_settings["account_mode"] == "per_task"
+            and selected_account
+            and not force_new
+        ):
             return selected_account
         picked = account_pool.pick_random()
         return picked or selected_account
@@ -358,7 +482,11 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
         nonlocal selected_proxy
         if not rotation_settings["proxy_enabled"]:
             return None
-        if rotation_settings["proxy_mode"] == "per_task" and selected_proxy and not force_new:
+        if (
+            rotation_settings["proxy_mode"] == "per_task"
+            and selected_proxy
+            and not force_new
+        ):
             return selected_proxy
         picked = proxy_pool.pick_random()
         return picked or selected_proxy
@@ -380,12 +508,12 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
         async with async_playwright() as p:
             # 反检测启动参数
             launch_args = [
-                '--disable-blink-features=AutomationControlled',
-                '--disable-dev-shm-usage',
-                '--no-sandbox',
-                '--disable-setuid-sandbox',
-                '--disable-web-security',
-                '--disable-features=IsolateOrigins,site-per-process'
+                "--disable-blink-features=AutomationControlled",
+                "--disable-dev-shm-usage",
+                "--no-sandbox",
+                "--disable-setuid-sandbox",
+                "--disable-web-security",
+                "--disable-features=IsolateOrigins,site-per-process",
             ]
 
             launch_kwargs = {"headless": RUN_HEADLESS, "args": launch_args}
@@ -405,7 +533,10 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
 
             if isinstance(snapshot_data, dict):
                 # 新版扩展导出的增强快照，包含环境和Header
-                if any(key in snapshot_data for key in ("env", "headers", "page", "storage")):
+                if any(
+                    key in snapshot_data
+                    for key in ("env", "headers", "page", "storage")
+                ):
                     print(f"检测到增强浏览器快照，应用环境参数: {state_file}")
                     storage_state_arg = {"cookies": snapshot_data.get("cookies", [])}
                     context_kwargs.update(_build_context_overrides(snapshot_data))
@@ -416,7 +547,9 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                     storage_state_arg = snapshot_data
 
             context_kwargs = _clean_kwargs(context_kwargs)
-            context = await browser.new_context(storage_state=storage_state_arg, **context_kwargs)
+            context = await browser.new_context(
+                storage_state=storage_state_arg, **context_kwargs
+            )
 
             # 增强反检测脚本（模拟真实移动设备）
             await context.add_init_script("""
@@ -447,7 +580,11 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
             try:
                 # 步骤 0 - 模拟真实用户：先访问首页（重要的反检测措施）
                 log_time("步骤 0 - 模拟真实用户访问首页...")
-                await page.goto("https://www.goofish.com/", wait_until="domcontentloaded", timeout=30000)
+                await page.goto(
+                    "https://www.goofish.com/",
+                    wait_until="domcontentloaded",
+                    timeout=30000,
+                )
                 log_time("[反爬] 在首页停留，模拟浏览...")
                 await random_sleep(1, 2)
 
@@ -457,18 +594,33 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
 
                 log_time("步骤 1 - 导航到搜索结果页...")
                 # 使用 'q' 参数构建正确的搜索URL，并进行URL编码
-                params = {'q': keyword}
+                params = {"q": keyword}
                 search_url = f"https://www.goofish.com/search?{urlencode(params)}"
                 log_time(f"目标URL: {search_url}")
 
-                # 使用 expect_response 在导航的同时捕获初始搜索的API数据
-                async with page.expect_response(lambda r: API_URL_PATTERN in r.url, timeout=30000) as response_info:
-                    await page.goto(search_url, wait_until="domcontentloaded", timeout=60000)
+                # 先导航，再判断是否被重定向到登录页。
+                await page.goto(
+                    search_url, wait_until="domcontentloaded", timeout=60000
+                )
+                if _is_login_url(page.url):
+                    raise LoginRequiredError(
+                        f"Login required: redirected to {page.url} (cookies/state likely expired)"
+                    )
 
-                initial_response = await response_info.value
+                # 捕获初始搜索的API数据
+                initial_response = await page.wait_for_response(
+                    lambda r: API_URL_PATTERN in r.url, timeout=30000
+                )
 
                 # 等待页面加载出关键筛选元素，以确认已成功进入搜索结果页
-                await page.wait_for_selector('text=新发布', timeout=15000)
+                try:
+                    await page.wait_for_selector("text=新发布", timeout=15000)
+                except PlaywrightTimeoutError as e:
+                    if _is_login_url(page.url):
+                        raise LoginRequiredError(
+                            f"Login required: redirected to {page.url} (cookies/state likely expired)"
+                        ) from e
+                    raise
 
                 # 模拟真实用户行为：页面加载后的初始停留和浏览
                 log_time("[反爬] 模拟用户查看页面...")
@@ -479,15 +631,21 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                 middleware_widget = page.locator("div.J_MIDDLEWARE_FRAME_WIDGET")
                 try:
                     # 等待弹窗在2秒内出现。如果出现，则执行块内代码。
-                    await baxia_dialog.wait_for(state='visible', timeout=2000)
-                    print("\n==================== CRITICAL BLOCK DETECTED ====================")
+                    await baxia_dialog.wait_for(state="visible", timeout=2000)
+                    print(
+                        "\n==================== CRITICAL BLOCK DETECTED ===================="
+                    )
                     print("检测到闲鱼反爬虫验证弹窗 (baxia-dialog)，无法继续操作。")
                     print("这通常是因为操作过于频繁或被识别为机器人。")
                     print("建议：")
                     print("1. 停止脚本一段时间再试。")
-                    print("2. (推荐) 在 .env 文件中设置 RUN_HEADLESS=false，以非无头模式运行，这有助于绕过检测。")
+                    print(
+                        "2. (推荐) 在 .env 文件中设置 RUN_HEADLESS=false，以非无头模式运行，这有助于绕过检测。"
+                    )
                     print(f"任务 '{keyword}' 将在此处中止。")
-                    print("===================================================================")
+                    print(
+                        "==================================================================="
+                    )
                     raise RiskControlError("baxia-dialog")
                 except PlaywrightTimeoutError:
                     # 2秒内弹窗未出现，这是正常情况，继续执行
@@ -495,16 +653,22 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
 
                 # 检查是否有J_MIDDLEWARE_FRAME_WIDGET覆盖层
                 try:
-                    await middleware_widget.wait_for(state='visible', timeout=2000)
-                    print("\n==================== CRITICAL BLOCK DETECTED ====================")
-                    print("检测到闲鱼反爬虫验证弹窗 (J_MIDDLEWARE_FRAME_WIDGET)，无法继续操作。")
+                    await middleware_widget.wait_for(state="visible", timeout=2000)
+                    print(
+                        "\n==================== CRITICAL BLOCK DETECTED ===================="
+                    )
+                    print(
+                        "检测到闲鱼反爬虫验证弹窗 (J_MIDDLEWARE_FRAME_WIDGET)，无法继续操作。"
+                    )
                     print("这通常是因为操作过于频繁或被识别为机器人。")
                     print("建议：")
                     print("1. 停止脚本一段时间再试。")
                     print("2. (推荐) 更新登录状态文件，确保登录状态有效。")
                     print("3. 降低任务执行频率，避免被识别为机器人。")
                     print(f"任务 '{keyword}' 将在此处中止。")
-                    print("===================================================================")
+                    print(
+                        "==================================================================="
+                    )
                     raise RiskControlError("J_MIDDLEWARE_FRAME_WIDGET")
                 except PlaywrightTimeoutError:
                     # 2秒内弹窗未出现，这是正常情况，继续执行
@@ -521,29 +685,37 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                 log_time("步骤 2 - 应用筛选条件...")
                 if new_publish_option:
                     try:
-                        await page.click('text=新发布')
-                        await random_sleep(1, 2) # 原来是 (1.5, 2.5)
-                        async with page.expect_response(lambda r: API_URL_PATTERN in r.url, timeout=20000) as response_info:
+                        await page.click("text=新发布")
+                        await random_sleep(1, 2)  # 原来是 (1.5, 2.5)
+                        async with page.expect_response(
+                            lambda r: API_URL_PATTERN in r.url, timeout=20000
+                        ) as response_info:
                             await page.click(f"text={new_publish_option}")
                             # --- 修改: 增加排序后的等待时间 ---
-                            await random_sleep(2, 4) # 原来是 (3, 5)
+                            await random_sleep(2, 4)  # 原来是 (3, 5)
                         final_response = await response_info.value
                     except PlaywrightTimeoutError:
-                        log_time(f"新发布筛选 '{new_publish_option}' 请求超时，继续执行。")
+                        log_time(
+                            f"新发布筛选 '{new_publish_option}' 请求超时，继续执行。"
+                        )
                     except Exception as e:
                         print(f"LOG: 应用新发布筛选失败: {e}")
 
                 if personal_only:
-                    async with page.expect_response(lambda r: API_URL_PATTERN in r.url, timeout=20000) as response_info:
-                        await page.click('text=个人闲置')
+                    async with page.expect_response(
+                        lambda r: API_URL_PATTERN in r.url, timeout=20000
+                    ) as response_info:
+                        await page.click("text=个人闲置")
                         # --- 修改: 将固定等待改为随机等待，并加长 ---
-                        await random_sleep(2, 4) # 原来是 asyncio.sleep(5)
+                        await random_sleep(2, 4)  # 原来是 asyncio.sleep(5)
                     final_response = await response_info.value
 
                 if free_shipping:
                     try:
-                        async with page.expect_response(lambda r: API_URL_PATTERN in r.url, timeout=20000) as response_info:
-                            await page.click('text=包邮')
+                        async with page.expect_response(
+                            lambda r: API_URL_PATTERN in r.url, timeout=20000
+                        ) as response_info:
+                            await page.click("text=包邮")
                             await random_sleep(2, 4)
                         final_response = await response_info.value
                     except PlaywrightTimeoutError:
@@ -558,60 +730,93 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                             await area_trigger.first.click()
                             await random_sleep(1.5, 2)
                             popover_candidates = page.locator("div.ant-popover")
-                            popover = popover_candidates.filter(has=page.locator(".areaWrap--FaZHsn8E, [class*='areaWrap']")).last
+                            popover = popover_candidates.filter(
+                                has=page.locator(
+                                    ".areaWrap--FaZHsn8E, [class*='areaWrap']"
+                                )
+                            ).last
                             if not await popover.count():
-                                popover = popover_candidates.filter(has=page.get_by_text("重新定位")).last
+                                popover = popover_candidates.filter(
+                                    has=page.get_by_text("重新定位")
+                                ).last
                             if not await popover.count():
-                                popover = popover_candidates.filter(has=page.get_by_text("查看")).last
+                                popover = popover_candidates.filter(
+                                    has=page.get_by_text("查看")
+                                ).last
                             if not await popover.count():
                                 print("LOG: 未找到区域弹窗，跳过区域筛选。")
                                 raise PlaywrightTimeoutError("region-popover-not-found")
                             await popover.wait_for(state="visible", timeout=5000)
 
                             # 列表容器：第一层 children 即省/市/区三列，不再强依赖具体类名，提升鲁棒性
-                            area_wrap = popover.locator(".areaWrap--FaZHsn8E, [class*='areaWrap']").first
+                            area_wrap = popover.locator(
+                                ".areaWrap--FaZHsn8E, [class*='areaWrap']"
+                            ).first
                             await area_wrap.wait_for(state="visible", timeout=3000)
                             columns = area_wrap.locator(":scope > div")
                             col_prov = columns.nth(0)
                             col_city = columns.nth(1)
                             col_dist = columns.nth(2)
 
-                            region_parts = [p.strip() for p in region_filter.split('/') if p.strip()]
+                            region_parts = [
+                                p.strip() for p in region_filter.split("/") if p.strip()
+                            ]
 
-                            async def _click_in_column(column_locator, text_value: str, desc: str) -> None:
-                                option = column_locator.locator(".provItem--QAdOx8nD", has_text=text_value).first
+                            async def _click_in_column(
+                                column_locator, text_value: str, desc: str
+                            ) -> None:
+                                option = column_locator.locator(
+                                    ".provItem--QAdOx8nD", has_text=text_value
+                                ).first
                                 if await option.count():
                                     await option.click()
                                     await random_sleep(1.5, 2)
                                     try:
-                                        await option.wait_for(state="attached", timeout=1500)
-                                        await option.wait_for(state="visible", timeout=1500)
+                                        await option.wait_for(
+                                            state="attached", timeout=1500
+                                        )
+                                        await option.wait_for(
+                                            state="visible", timeout=1500
+                                        )
                                     except PlaywrightTimeoutError:
                                         pass
                                 else:
                                     print(f"LOG: 未找到{desc} '{text_value}'，跳过。")
 
                             if len(region_parts) >= 1:
-                                await _click_in_column(col_prov, region_parts[0], "省份")
+                                await _click_in_column(
+                                    col_prov, region_parts[0], "省份"
+                                )
                                 await random_sleep(1, 2)
                             if len(region_parts) >= 2:
-                                await _click_in_column(col_city, region_parts[1], "城市")
+                                await _click_in_column(
+                                    col_city, region_parts[1], "城市"
+                                )
                                 await random_sleep(1, 2)
                             if len(region_parts) >= 3:
-                                await _click_in_column(col_dist, region_parts[2], "区/县")
+                                await _click_in_column(
+                                    col_dist, region_parts[2], "区/县"
+                                )
                                 await random_sleep(1, 2)
 
-                            search_btn = popover.locator("div.searchBtn--Ic6RKcAb").first
+                            search_btn = popover.locator(
+                                "div.searchBtn--Ic6RKcAb"
+                            ).first
                             if await search_btn.count():
                                 try:
-                                    async with page.expect_response(lambda r: API_URL_PATTERN in r.url, timeout=20000) as response_info:
+                                    async with page.expect_response(
+                                        lambda r: API_URL_PATTERN in r.url,
+                                        timeout=20000,
+                                    ) as response_info:
                                         await search_btn.click()
                                         await random_sleep(2, 3)
                                     final_response = await response_info.value
                                 except PlaywrightTimeoutError:
                                     log_time("区域筛选提交超时，继续执行。")
                             else:
-                                print("LOG: 未找到区域弹窗的“查看XX件宝贝”按钮，跳过提交。")
+                                print(
+                                    "LOG: 未找到区域弹窗的“查看XX件宝贝”按钮，跳过提交。"
+                                )
                         else:
                             print("LOG: 未找到区域筛选触发器。")
                     except PlaywrightTimeoutError:
@@ -620,28 +825,42 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                         print(f"LOG: 应用区域筛选 '{region_filter}' 失败: {e}")
 
                 if min_price or max_price:
-                    price_container = page.locator('div[class*="search-price-input-container"]').first
+                    price_container = page.locator(
+                        'div[class*="search-price-input-container"]'
+                    ).first
                     if await price_container.is_visible():
                         if min_price:
-                            await price_container.get_by_placeholder("¥").first.fill(min_price)
+                            await price_container.get_by_placeholder("¥").first.fill(
+                                min_price
+                            )
                             # --- 修改: 将固定等待改为随机等待 ---
-                            await random_sleep(1, 2.5) # 原来是 asyncio.sleep(5)
+                            await random_sleep(1, 2.5)  # 原来是 asyncio.sleep(5)
                         if max_price:
-                            await price_container.get_by_placeholder("¥").nth(1).fill(max_price)
+                            await (
+                                price_container.get_by_placeholder("¥")
+                                .nth(1)
+                                .fill(max_price)
+                            )
                             # --- 修改: 将固定等待改为随机等待 ---
-                            await random_sleep(1, 2.5) # 原来是 asyncio.sleep(5)
+                            await random_sleep(1, 2.5)  # 原来是 asyncio.sleep(5)
 
-                        async with page.expect_response(lambda r: API_URL_PATTERN in r.url, timeout=20000) as response_info:
-                            await page.keyboard.press('Tab')
+                        async with page.expect_response(
+                            lambda r: API_URL_PATTERN in r.url, timeout=20000
+                        ) as response_info:
+                            await page.keyboard.press("Tab")
                             # --- 修改: 增加确认价格后的等待时间 ---
-                            await random_sleep(2, 4) # 原来是 asyncio.sleep(5)
+                            await random_sleep(2, 4)  # 原来是 asyncio.sleep(5)
                         final_response = await response_info.value
                     else:
                         print("LOG: 警告 - 未找到价格输入容器。")
 
                 log_time("所有筛选已完成，开始处理商品列表...")
 
-                current_response = final_response if final_response and final_response.ok else initial_response
+                current_response = (
+                    final_response
+                    if final_response and final_response.ok
+                    else initial_response
+                )
                 for page_num in range(1, max_pages + 1):
                     if stop_scraping:
                         break
@@ -649,15 +868,21 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
 
                     if page_num > 1:
                         # 查找未被禁用的“下一页”按钮。闲鱼通过添加 'disabled' 类名来禁用按钮，而不是使用 disabled 属性。
-                        next_btn = page.locator("[class*='search-pagination-arrow-right']:not([class*='disabled'])")
+                        next_btn = page.locator(
+                            "[class*='search-pagination-arrow-right']:not([class*='disabled'])"
+                        )
                         if not await next_btn.count():
-                            log_time("已到达最后一页，未找到可用的‘下一页’按钮，停止翻页。")
+                            log_time(
+                                "已到达最后一页，未找到可用的‘下一页’按钮，停止翻页。"
+                            )
                             break
                         try:
-                            async with page.expect_response(lambda r: API_URL_PATTERN in r.url, timeout=20000) as response_info:
+                            async with page.expect_response(
+                                lambda r: API_URL_PATTERN in r.url, timeout=20000
+                            ) as response_info:
                                 await next_btn.click()
                                 # --- 修改: 增加翻页后的等待时间 ---
-                                await random_sleep(2, 5) # 原来是 (1.5, 3.5)
+                                await random_sleep(2, 5)  # 原来是 (1.5, 3.5)
                             current_response = await response_info.value
                         except PlaywrightTimeoutError:
                             log_time(f"翻页到第 {page_num} 页超时，停止翻页。")
@@ -667,123 +892,194 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                         log_time(f"第 {page_num} 页响应无效，跳过。")
                         continue
 
-                    basic_items = await _parse_search_results_json(await current_response.json(), f"第 {page_num} 页")
+                    basic_items = await _parse_search_results_json(
+                        await current_response.json(), f"第 {page_num} 页"
+                    )
                     if not basic_items:
                         break
 
                     total_items_on_page = len(basic_items)
                     for i, item_data in enumerate(basic_items, 1):
                         if debug_limit > 0 and processed_item_count >= debug_limit:
-                            log_time(f"已达到调试上限 ({debug_limit})，停止获取新商品。")
+                            log_time(
+                                f"已达到调试上限 ({debug_limit})，停止获取新商品。"
+                            )
                             stop_scraping = True
                             break
 
                         unique_key = get_link_unique_key(item_data["商品链接"])
                         if unique_key in processed_links:
-                            log_time(f"[页内进度 {i}/{total_items_on_page}] 商品 '{item_data['商品标题'][:20]}...' 已存在，跳过。")
+                            log_time(
+                                f"[页内进度 {i}/{total_items_on_page}] 商品 '{item_data['商品标题'][:20]}...' 已存在，跳过。"
+                            )
                             continue
 
-                        log_time(f"[页内进度 {i}/{total_items_on_page}] 发现新商品，获取详情: {item_data['商品标题'][:30]}...")
+                        log_time(
+                            f"[页内进度 {i}/{total_items_on_page}] 发现新商品，获取详情: {item_data['商品标题'][:30]}..."
+                        )
                         # --- 修改: 访问详情页前的等待时间，模拟用户在列表页上看了一会儿 ---
-                        await random_sleep(2, 4) # 原来是 (2, 4)
+                        await random_sleep(2, 4)  # 原来是 (2, 4)
 
                         detail_page = await context.new_page()
                         try:
-                            async with detail_page.expect_response(lambda r: DETAIL_API_URL_PATTERN in r.url, timeout=25000) as detail_info:
-                                await detail_page.goto(item_data["商品链接"], wait_until="domcontentloaded", timeout=25000)
+                            async with detail_page.expect_response(
+                                lambda r: DETAIL_API_URL_PATTERN in r.url, timeout=25000
+                            ) as detail_info:
+                                await detail_page.goto(
+                                    item_data["商品链接"],
+                                    wait_until="domcontentloaded",
+                                    timeout=25000,
+                                )
 
                             detail_response = await detail_info.value
                             if detail_response.ok:
                                 detail_json = await detail_response.json()
 
-                                ret_string = str(await safe_get(detail_json, 'ret', default=[]))
+                                ret_string = str(
+                                    await safe_get(detail_json, "ret", default=[])
+                                )
                                 if "FAIL_SYS_USER_VALIDATE" in ret_string:
-                                    print("\n==================== CRITICAL BLOCK DETECTED ====================")
-                                    print("检测到闲鱼反爬虫验证 (FAIL_SYS_USER_VALIDATE)，程序将终止。")
+                                    print(
+                                        "\n==================== CRITICAL BLOCK DETECTED ===================="
+                                    )
+                                    print(
+                                        "检测到闲鱼反爬虫验证 (FAIL_SYS_USER_VALIDATE)，程序将终止。"
+                                    )
                                     long_sleep_duration = random.randint(3, 60)
-                                    print(f"为避免账户风险，将执行一次长时间休眠 ({long_sleep_duration} 秒) 后再退出...")
+                                    print(
+                                        f"为避免账户风险，将执行一次长时间休眠 ({long_sleep_duration} 秒) 后再退出..."
+                                    )
                                     await asyncio.sleep(long_sleep_duration)
                                     print("长时间休眠结束，现在将安全退出。")
-                                    print("===================================================================")
+                                    print(
+                                        "==================================================================="
+                                    )
                                     raise RiskControlError("FAIL_SYS_USER_VALIDATE")
 
                                 # 解析商品详情数据并更新 item_data
-                                item_do = await safe_get(detail_json, 'data', 'itemDO', default={})
-                                seller_do = await safe_get(detail_json, 'data', 'sellerDO', default={})
+                                item_do = await safe_get(
+                                    detail_json, "data", "itemDO", default={}
+                                )
+                                seller_do = await safe_get(
+                                    detail_json, "data", "sellerDO", default={}
+                                )
 
-                                reg_days_raw = await safe_get(seller_do, 'userRegDay', default=0)
-                                registration_duration_text = format_registration_days(reg_days_raw)
+                                reg_days_raw = await safe_get(
+                                    seller_do, "userRegDay", default=0
+                                )
+                                registration_duration_text = format_registration_days(
+                                    reg_days_raw
+                                )
 
                                 # --- START: 新增代码块 ---
 
                                 # 1. 提取卖家的芝麻信用信息
-                                zhima_credit_text = await safe_get(seller_do, 'zhimaLevelInfo', 'levelName')
+                                zhima_credit_text = await safe_get(
+                                    seller_do, "zhimaLevelInfo", "levelName"
+                                )
 
                                 # 2. 提取该商品的完整图片列表
-                                image_infos = await safe_get(item_do, 'imageInfos', default=[])
+                                image_infos = await safe_get(
+                                    item_do, "imageInfos", default=[]
+                                )
                                 if image_infos:
                                     # 使用列表推导式获取所有有效的图片URL
-                                    all_image_urls = [img.get('url') for img in image_infos if img.get('url')]
+                                    all_image_urls = [
+                                        img.get("url")
+                                        for img in image_infos
+                                        if img.get("url")
+                                    ]
                                     if all_image_urls:
                                         # 用新的字段存储图片列表，替换掉旧的单个链接
-                                        item_data['商品图片列表'] = all_image_urls
+                                        item_data["商品图片列表"] = all_image_urls
                                         # (可选) 仍然保留主图链接，以防万一
-                                        item_data['商品主图链接'] = all_image_urls[0]
+                                        item_data["商品主图链接"] = all_image_urls[0]
 
                                 # --- END: 新增代码块 ---
-                                item_data['“想要”人数'] = await safe_get(item_do, 'wantCnt', default=item_data.get('“想要”人数', 'NaN'))
-                                item_data['浏览量'] = await safe_get(item_do, 'browseCnt', default='-')
+                                item_data["“想要”人数"] = await safe_get(
+                                    item_do,
+                                    "wantCnt",
+                                    default=item_data.get("“想要”人数", "NaN"),
+                                )
+                                item_data["浏览量"] = await safe_get(
+                                    item_do, "browseCnt", default="-"
+                                )
                                 # ...[此处可添加更多从详情页解析出的商品信息]...
 
                                 # 调用核心函数采集卖家信息
                                 user_profile_data = {}
-                                user_id = await safe_get(seller_do, 'sellerId')
+                                user_id = await safe_get(seller_do, "sellerId")
                                 if user_id:
                                     # 新的、高效的调用方式:
-                                    user_profile_data = await scrape_user_profile(context, str(user_id))
+                                    user_profile_data = await scrape_user_profile(
+                                        context, str(user_id)
+                                    )
                                 else:
                                     print("   [警告] 未能从详情API中获取到卖家ID。")
-                                user_profile_data['卖家芝麻信用'] = zhima_credit_text
-                                user_profile_data['卖家注册时长'] = registration_duration_text
+                                user_profile_data["卖家芝麻信用"] = zhima_credit_text
+                                user_profile_data["卖家注册时长"] = (
+                                    registration_duration_text
+                                )
 
                                 # 构建基础记录
                                 final_record = {
                                     "爬取时间": datetime.now().isoformat(),
                                     "搜索关键字": keyword,
-                                    "任务名称": task_config.get('task_name', 'Untitled Task'),
+                                    "任务名称": task_config.get(
+                                        "task_name", "Untitled Task"
+                                    ),
                                     "商品信息": item_data,
-                                    "卖家信息": user_profile_data
+                                    "卖家信息": user_profile_data,
                                 }
 
                                 # --- START: Real-time Analysis & Notification ---
                                 ai_analysis_result = None
                                 if decision_mode == "keyword":
                                     search_text = build_search_text(final_record)
-                                    ai_analysis_result = evaluate_keyword_rules(keyword_rules, search_text)
+                                    ai_analysis_result = evaluate_keyword_rules(
+                                        keyword_rules, search_text
+                                    )
                                     final_record["ai_analysis"] = ai_analysis_result
-                                    log_time(f"关键词判断完成。推荐状态: {ai_analysis_result.get('is_recommended')}")
+                                    log_time(
+                                        f"关键词判断完成。推荐状态: {ai_analysis_result.get('is_recommended')}"
+                                    )
 
                                     if ai_analysis_result.get("is_recommended"):
                                         log_time("商品命中关键词规则，准备发送通知...")
-                                        await send_ntfy_notification(item_data, ai_analysis_result.get("reason", "无"))
+                                        await send_ntfy_notification(
+                                            item_data,
+                                            ai_analysis_result.get("reason", "无"),
+                                        )
                                 else:
                                     from src.config import SKIP_AI_ANALYSIS
 
                                     # 检查是否跳过AI分析并直接发送通知
                                     if SKIP_AI_ANALYSIS:
-                                        log_time("环境变量 SKIP_AI_ANALYSIS 已设置，跳过AI分析并直接发送通知...")
+                                        log_time(
+                                            "环境变量 SKIP_AI_ANALYSIS 已设置，跳过AI分析并直接发送通知..."
+                                        )
                                         # 下载图片
-                                        image_urls = item_data.get('商品图片列表', [])
-                                        downloaded_image_paths = await download_all_images(item_data['商品ID'], image_urls, task_config.get('task_name', 'default'))
+                                        image_urls = item_data.get("商品图片列表", [])
+                                        downloaded_image_paths = (
+                                            await download_all_images(
+                                                item_data["商品ID"],
+                                                image_urls,
+                                                task_config.get("task_name", "default"),
+                                            )
+                                        )
 
                                         # 删除下载的图片文件，节省空间
                                         for img_path in downloaded_image_paths:
                                             try:
                                                 if os.path.exists(img_path):
                                                     os.remove(img_path)
-                                                    print(f"   [图片] 已删除临时图片文件: {img_path}")
+                                                    print(
+                                                        f"   [图片] 已删除临时图片文件: {img_path}"
+                                                    )
                                             except Exception as e:
-                                                print(f"   [图片] 删除图片文件时出错: {e}")
+                                                print(
+                                                    f"   [图片] 删除图片文件时出错: {e}"
+                                                )
 
                                         ai_analysis_result = {
                                             "analysis_source": "ai",
@@ -795,23 +1091,47 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
 
                                         # 直接发送通知，将所有商品标记为推荐
                                         log_time("商品已跳过AI分析，准备发送通知...")
-                                        await send_ntfy_notification(item_data, ai_analysis_result["reason"])
+                                        await send_ntfy_notification(
+                                            item_data, ai_analysis_result["reason"]
+                                        )
                                     else:
-                                        log_time(f"开始对商品 #{item_data['商品ID']} 进行实时AI分析...")
+                                        log_time(
+                                            f"开始对商品 #{item_data['商品ID']} 进行实时AI分析..."
+                                        )
                                         # 1. Download images
-                                        image_urls = item_data.get('商品图片列表', [])
-                                        downloaded_image_paths = await download_all_images(item_data['商品ID'], image_urls, task_config.get('task_name', 'default'))
+                                        image_urls = item_data.get("商品图片列表", [])
+                                        downloaded_image_paths = (
+                                            await download_all_images(
+                                                item_data["商品ID"],
+                                                image_urls,
+                                                task_config.get("task_name", "default"),
+                                            )
+                                        )
 
                                         # 2. Get AI analysis
                                         if ai_prompt_text:
                                             try:
                                                 # 注意：这里我们将整个记录传给AI，让它拥有最全的上下文
-                                                ai_analysis_result = await get_ai_analysis(final_record, downloaded_image_paths, prompt_text=ai_prompt_text)
+                                                ai_analysis_result = (
+                                                    await get_ai_analysis(
+                                                        final_record,
+                                                        downloaded_image_paths,
+                                                        prompt_text=ai_prompt_text,
+                                                    )
+                                                )
                                                 if ai_analysis_result:
-                                                    ai_analysis_result.setdefault("analysis_source", "ai")
-                                                    ai_analysis_result.setdefault("keyword_hit_count", 0)
-                                                    final_record['ai_analysis'] = ai_analysis_result
-                                                    log_time(f"AI分析完成。推荐状态: {ai_analysis_result.get('is_recommended')}")
+                                                    ai_analysis_result.setdefault(
+                                                        "analysis_source", "ai"
+                                                    )
+                                                    ai_analysis_result.setdefault(
+                                                        "keyword_hit_count", 0
+                                                    )
+                                                    final_record["ai_analysis"] = (
+                                                        ai_analysis_result
+                                                    )
+                                                    log_time(
+                                                        f"AI分析完成。推荐状态: {ai_analysis_result.get('is_recommended')}"
+                                                    )
                                                 else:
                                                     ai_analysis_result = {
                                                         "analysis_source": "ai",
@@ -820,9 +1140,13 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                                                         "error": "AI analysis returned None after retries.",
                                                         "keyword_hit_count": 0,
                                                     }
-                                                    final_record['ai_analysis'] = ai_analysis_result
+                                                    final_record["ai_analysis"] = (
+                                                        ai_analysis_result
+                                                    )
                                             except Exception as e:
-                                                print(f"   -> AI分析过程中发生严重错误: {e}")
+                                                print(
+                                                    f"   -> AI分析过程中发生严重错误: {e}"
+                                                )
                                                 ai_analysis_result = {
                                                     "analysis_source": "ai",
                                                     "is_recommended": False,
@@ -830,30 +1154,46 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                                                     "error": str(e),
                                                     "keyword_hit_count": 0,
                                                 }
-                                                final_record['ai_analysis'] = ai_analysis_result
+                                                final_record["ai_analysis"] = (
+                                                    ai_analysis_result
+                                                )
                                         else:
-                                            print("   -> 任务未配置AI prompt，跳过分析。")
+                                            print(
+                                                "   -> 任务未配置AI prompt，跳过分析。"
+                                            )
                                             ai_analysis_result = {
                                                 "analysis_source": "ai",
                                                 "is_recommended": False,
                                                 "reason": "任务未配置AI prompt，跳过分析。",
                                                 "keyword_hit_count": 0,
                                             }
-                                            final_record["ai_analysis"] = ai_analysis_result
+                                            final_record["ai_analysis"] = (
+                                                ai_analysis_result
+                                            )
 
                                         # 删除下载的图片文件，节省空间
                                         for img_path in downloaded_image_paths:
                                             try:
                                                 if os.path.exists(img_path):
                                                     os.remove(img_path)
-                                                    print(f"   [图片] 已删除临时图片文件: {img_path}")
+                                                    print(
+                                                        f"   [图片] 已删除临时图片文件: {img_path}"
+                                                    )
                                             except Exception as e:
-                                                print(f"   [图片] 删除图片文件时出错: {e}")
+                                                print(
+                                                    f"   [图片] 删除图片文件时出错: {e}"
+                                                )
 
                                         # 3. Send notification if recommended
-                                        if ai_analysis_result and ai_analysis_result.get('is_recommended'):
+                                        if (
+                                            ai_analysis_result
+                                            and ai_analysis_result.get("is_recommended")
+                                        ):
                                             log_time("商品被AI推荐，准备发送通知...")
-                                            await send_ntfy_notification(item_data, ai_analysis_result.get("reason", "无"))
+                                            await send_ntfy_notification(
+                                                item_data,
+                                                ai_analysis_result.get("reason", "无"),
+                                            )
                                 # --- END: Real-time Analysis & Notification ---
 
                                 # 4. 保存包含AI结果的完整记录
@@ -861,20 +1201,30 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
 
                                 processed_links.add(unique_key)
                                 processed_item_count += 1
-                                log_time(f"商品处理流程完毕。累计处理 {processed_item_count} 个新商品。")
+                                log_time(
+                                    f"商品处理流程完毕。累计处理 {processed_item_count} 个新商品。"
+                                )
 
                                 # --- 修改: 增加单个商品处理后的主要延迟 ---
-                                log_time("[反爬] 执行一次主要的随机延迟以模拟用户浏览间隔...")
+                                log_time(
+                                    "[反爬] 执行一次主要的随机延迟以模拟用户浏览间隔..."
+                                )
                                 await random_sleep(5, 10)
                             else:
-                                print(f"   错误: 获取商品详情API响应失败，状态码: {detail_response.status}")
+                                print(
+                                    f"   错误: 获取商品详情API响应失败，状态码: {detail_response.status}"
+                                )
                                 if AI_DEBUG_MODE:
-                                    print(f"--- [DETAIL DEBUG] FAILED RESPONSE from {item_data['商品链接']} ---")
+                                    print(
+                                        f"--- [DETAIL DEBUG] FAILED RESPONSE from {item_data['商品链接']} ---"
+                                    )
                                     try:
                                         print(await detail_response.text())
                                     except Exception as e:
                                         print(f"无法读取响应内容: {e}")
-                                    print("----------------------------------------------------")
+                                    print(
+                                        "----------------------------------------------------"
+                                    )
 
                         except PlaywrightTimeoutError:
                             print(f"   错误: 访问商品详情页或等待API响应超时。")
@@ -883,14 +1233,20 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                         finally:
                             await detail_page.close()
                             # --- 修改: 增加关闭页面后的短暂整理时间 ---
-                            await random_sleep(2, 4) # 原来是 (1, 2.5)
+                            await random_sleep(2, 4)  # 原来是 (1, 2.5)
 
                     # --- 新增: 在处理完一页所有商品后，翻页前，增加一个更长的“休息”时间 ---
                     if not stop_scraping and page_num < max_pages:
-                        print(f"--- 第 {page_num} 页处理完毕，准备翻页。执行一次页面间的长时休息... ---")
+                        print(
+                            f"--- 第 {page_num} 页处理完毕，准备翻页。执行一次页面间的长时休息... ---"
+                        )
                         await random_sleep(10, 15)
 
             except PlaywrightTimeoutError as e:
+                if _is_login_url(page.url):
+                    raise LoginRequiredError(
+                        f"Login required: redirected to {page.url} (cookies/state likely expired)"
+                    ) from e
                 print(f"\n操作超时错误: 页面元素或网络响应未在规定时间内出现。\n{e}")
                 raise
             except asyncio.CancelledError:
@@ -900,6 +1256,10 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
                 if type(e).__name__ == "TargetClosedError":
                     log_time("浏览器已关闭，忽略后续异常（可能是任务被停止）。")
                     return processed_item_count
+                if "passport.goofish.com" in str(e):
+                    raise LoginRequiredError(
+                        f"Login required: redirected to passport flow ({e})"
+                    ) from e
                 print(f"\n爬取过程中发生未知错误: {e}")
                 raise
             finally:
@@ -912,32 +1272,85 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
         return processed_item_count
 
     processed_item_count = 0
-    attempt_limit = max(rotation_settings["account_retry_limit"], rotation_settings["proxy_retry_limit"], 1)
+    attempt_limit = max(
+        rotation_settings["account_retry_limit"],
+        rotation_settings["proxy_retry_limit"],
+        1,
+    )
     last_error = ""
+    last_state_path: Optional[str] = None
+
+    # If this task is already in a paused state, skip immediately.
+    task_name_for_guard = task_config.get("task_name", "未命名任务")
+    pause_cookie_path = None
+    if (
+        isinstance(task_config.get("account_state_file"), str)
+        and task_config.get("account_state_file").strip()
+    ):
+        pause_cookie_path = task_config.get("account_state_file").strip()
+    elif os.path.exists(STATE_FILE):
+        pause_cookie_path = STATE_FILE
+
+    decision = FAILURE_GUARD.should_skip_start(
+        task_name_for_guard, cookie_path=pause_cookie_path
+    )
+    if decision.skip:
+        print(
+            f"[FailureGuard] 任务 '{task_name_for_guard}' 已暂停重试 (连续失败 {decision.consecutive_failures}/{FAILURE_GUARD.threshold})"
+        )
+        if decision.should_notify:
+            try:
+                await send_ntfy_notification(
+                    {
+                        "商品标题": f"[任务暂停] {task_name_for_guard}",
+                        "当前售价": "N/A",
+                        "商品链接": "#",
+                    },
+                    "任务处于暂停状态，将跳过执行。\n"
+                    f"原因: {decision.reason}\n"
+                    f"连续失败: {decision.consecutive_failures}/{FAILURE_GUARD.threshold}\n"
+                    f"暂停到: {decision.paused_until.strftime('%Y-%m-%d %H:%M:%S') if decision.paused_until else 'N/A'}\n"
+                    "修复方法: 更新登录态/cookies文件后会自动恢复。",
+                )
+            except Exception as e:
+                print(f"发送任务暂停通知失败: {e}")
+
+        cleanup_task_images(task_config.get("task_name", "default"))
+        return 0
 
     for attempt in range(1, attempt_limit + 1):
         if attempt == 1:
             selected_account = _select_account()
             selected_proxy = _select_proxy()
         else:
-            if rotation_settings["account_enabled"] and rotation_settings["account_mode"] == "on_failure":
+            if (
+                rotation_settings["account_enabled"]
+                and rotation_settings["account_mode"] == "on_failure"
+            ):
                 account_pool.mark_bad(selected_account, last_error)
                 selected_account = _select_account(force_new=True)
-            if rotation_settings["proxy_enabled"] and rotation_settings["proxy_mode"] == "on_failure":
+            if (
+                rotation_settings["proxy_enabled"]
+                and rotation_settings["proxy_mode"] == "on_failure"
+            ):
                 proxy_pool.mark_bad(selected_proxy, last_error)
                 selected_proxy = _select_proxy(force_new=True)
 
         if rotation_settings["account_enabled"] and not selected_account:
-            print("未找到可用的登录状态文件，无法继续执行任务。")
+            last_error = "未找到可用的登录状态文件，无法继续执行任务。"
+            print(last_error)
             break
         if not rotation_settings["account_enabled"] and not selected_account:
-            print("未找到可用的登录状态文件，无法继续执行任务。")
+            last_error = "未找到可用的登录状态文件，无法继续执行任务。"
+            print(last_error)
             break
         if rotation_settings["proxy_enabled"] and not selected_proxy:
-            print("未找到可用的代理地址，无法继续执行任务。")
+            last_error = "未找到可用的代理地址，无法继续执行任务。"
+            print(last_error)
             break
 
         state_path = selected_account.value if selected_account else STATE_FILE
+        last_state_path = state_path
         proxy_server = selected_proxy.value if selected_proxy else None
         if rotation_settings["account_enabled"]:
             print(f"账号轮换：使用登录状态 {state_path}")
@@ -946,19 +1359,28 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
 
         try:
             processed_item_count += await _run_scrape_attempt(state_path, proxy_server)
+            last_error = ""
+            FAILURE_GUARD.record_success(task_name_for_guard)
+            break
+        except LoginRequiredError as e:
+            last_error = str(e)
+            print(f"检测到登录失效/重定向: {e}")
             break
         except RiskControlError as e:
             last_error = str(e)
             print(f"检测到风控或验证触发: {e}")
-            if attempt < attempt_limit:
-                print("将尝试轮换账号/IP 后重试...")
+            # 风控验证通常不是简单轮换能解决的，避免无意义重试。
+            break
         except Exception as e:
             last_error = f"{type(e).__name__}: {e}"
             print(f"本次尝试失败: {last_error}")
             if attempt < attempt_limit:
                 print("将尝试轮换账号/IP 后重试...")
 
+    if last_error:
+        await _notify_task_failure(task_config, last_error, cookie_path=last_state_path)
+
     # 清理任务图片目录
-    cleanup_task_images(task_config.get('task_name', 'default'))
+    cleanup_task_images(task_config.get("task_name", "default"))
 
     return processed_item_count

--- a/src/services/process_service.py
+++ b/src/services/process_service.py
@@ -2,13 +2,19 @@
 进程管理服务
 负责管理爬虫进程的启动和停止
 """
+
 import asyncio
+import contextlib
+import json
 import sys
 import os
 import signal
 from datetime import datetime
 from typing import Dict
 from src.utils import build_task_log_path
+from src.failure_guard import FailureGuard
+from src.config import STATE_FILE
+from src.ai_handler import send_ntfy_notification
 
 
 class ProcessService:
@@ -17,6 +23,28 @@ class ProcessService:
     def __init__(self):
         self.processes: Dict[int, asyncio.subprocess.Process] = {}
         self.log_paths: Dict[int, str] = {}
+        self.failure_guard = FailureGuard()
+
+    def _resolve_cookie_path(self, task_name: str) -> str | None:
+        """Best-effort cookie/state path for a task.
+
+        - Prefer task-specific account_state_file from config.json
+        - Fall back to global STATE_FILE (xianyu_state.json)
+        """
+        try:
+            if os.path.exists("config.json"):
+                with open("config.json", "r", encoding="utf-8") as f:
+                    tasks = json.load(f)
+                if isinstance(tasks, list):
+                    for t in tasks:
+                        if isinstance(t, dict) and t.get("task_name") == task_name:
+                            val = t.get("account_state_file")
+                            if isinstance(val, str) and val.strip():
+                                return val.strip()
+        except Exception:
+            pass
+
+        return STATE_FILE if os.path.exists(STATE_FILE) else None
 
     def is_running(self, task_id: int) -> bool:
         """检查任务是否正在运行"""
@@ -29,10 +57,37 @@ class ProcessService:
             print(f"任务 '{task_name}' (ID: {task_id}) 已在运行中")
             return False
 
+        cookie_path = self._resolve_cookie_path(task_name)
+        decision = self.failure_guard.should_skip_start(
+            task_name,
+            cookie_path=cookie_path,
+        )
+        if decision.skip:
+            print(
+                f"[FailureGuard] 跳过启动任务 '{task_name}'，已暂停重试 (连续失败 {decision.consecutive_failures}/{self.failure_guard.threshold})"
+            )
+            if decision.should_notify:
+                try:
+                    await send_ntfy_notification(
+                        {
+                            "商品标题": f"[任务暂停] {task_name}",
+                            "当前售价": "N/A",
+                            "商品链接": "#",
+                        },
+                        "任务处于暂停状态，将跳过执行。\n"
+                        f"原因: {decision.reason}\n"
+                        f"连续失败: {decision.consecutive_failures}/{self.failure_guard.threshold}\n"
+                        f"暂停到: {decision.paused_until.strftime('%Y-%m-%d %H:%M:%S') if decision.paused_until else 'N/A'}\n"
+                        "修复方法: 更新登录态/cookies文件后会自动恢复。",
+                    )
+                except Exception as e:
+                    print(f"发送任务暂停通知失败: {e}")
+            return False
+
         try:
             os.makedirs("logs", exist_ok=True)
             log_file_path = build_task_log_path(task_id, task_name)
-            log_file_handle = open(log_file_path, 'a', encoding='utf-8')
+            log_file_handle = open(log_file_path, "a", encoding="utf-8")
 
             preexec_fn = os.setsid if sys.platform != "win32" else None
             child_env = os.environ.copy()
@@ -40,11 +95,15 @@ class ProcessService:
             child_env["PYTHONUTF8"] = "1"
 
             process = await asyncio.create_subprocess_exec(
-                sys.executable, "-u", "spider_v2.py", "--task-name", task_name,
+                sys.executable,
+                "-u",
+                "spider_v2.py",
+                "--task-name",
+                task_name,
                 stdout=log_file_handle,
                 stderr=log_file_handle,
                 preexec_fn=preexec_fn,
-                env=child_env
+                env=child_env,
             )
 
             self.processes[task_id] = process
@@ -62,8 +121,8 @@ class ProcessService:
         if not log_path:
             return
         try:
-            ts = datetime.now().strftime(' %Y-%m-%d %H:%M:%S')
-            with open(log_path, 'a', encoding='utf-8') as f:
+            ts = datetime.now().strftime(" %Y-%m-%d %H:%M:%S")
+            with open(log_path, "a", encoding="utf-8") as f:
                 f.write(f"[{ts}] !!! 任务已被终止 !!!\n")
         except Exception as e:
             print(f"写入任务终止标记失败: {e}")
@@ -88,7 +147,9 @@ class ProcessService:
             try:
                 await asyncio.wait_for(process.wait(), timeout=20)
             except asyncio.TimeoutError:
-                print(f"任务进程 {process.pid} (ID: {task_id}) 未在 20 秒内退出，准备强制终止...")
+                print(
+                    f"任务进程 {process.pid} (ID: {task_id}) 未在 20 秒内退出，准备强制终止..."
+                )
                 if sys.platform != "win32":
                     with contextlib.suppress(ProcessLookupError):
                         os.killpg(os.getpgid(process.pid), signal.SIGKILL)

--- a/tests/test_failure_guard.py
+++ b/tests/test_failure_guard.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from src.failure_guard import FailureGuard
+
+
+def test_failure_guard_opens_circuit_after_threshold_and_rate_limits(tmp_path):
+    guard_path = tmp_path / "guard.json"
+    cookie_path = tmp_path / "xianyu_state.json"
+    cookie_path.write_text("{}", encoding="utf-8")
+
+    guard = FailureGuard(
+        path=str(guard_path),
+        threshold=3,
+        pause_seconds=3 * 24 * 60 * 60,
+        tz_name="Asia/Shanghai",
+    )
+
+    base = datetime(2026, 3, 4, 12, 0, 0)
+
+    r1 = guard.record_failure("task-a", "err-1", cookie_path=str(cookie_path), now=base)
+    assert r1["should_notify"] is False
+    assert r1["opened_circuit"] is False
+
+    r2 = guard.record_failure("task-a", "err-2", cookie_path=str(cookie_path), now=base)
+    assert r2["should_notify"] is False
+    assert r2["opened_circuit"] is False
+
+    r3 = guard.record_failure("task-a", "err-3", cookie_path=str(cookie_path), now=base)
+    assert r3["should_notify"] is True
+    assert r3["opened_circuit"] is True
+    assert r3["paused_until"] is not None
+
+    d0 = guard.should_skip_start("task-a", cookie_path=str(cookie_path), now=base)
+    assert d0.skip is True
+    assert d0.should_notify is False
+
+    next_day = base + timedelta(days=1, minutes=1)
+    d1 = guard.should_skip_start("task-a", cookie_path=str(cookie_path), now=next_day)
+    assert d1.skip is True
+    assert d1.should_notify is True
+
+    d1b = guard.should_skip_start("task-a", cookie_path=str(cookie_path), now=next_day)
+    assert d1b.skip is True
+    assert d1b.should_notify is False
+
+
+def test_failure_guard_auto_recovers_on_cookie_change(tmp_path):
+    guard_path = tmp_path / "guard.json"
+    cookie_path = tmp_path / "xianyu_state.json"
+    cookie_path.write_text("{}", encoding="utf-8")
+
+    guard = FailureGuard(
+        path=str(guard_path),
+        threshold=2,
+        pause_seconds=3 * 24 * 60 * 60,
+        tz_name="Asia/Shanghai",
+    )
+
+    base = datetime(2026, 3, 4, 12, 0, 0)
+
+    guard.record_failure("task-a", "err-1", cookie_path=str(cookie_path), now=base)
+    guard.record_failure("task-a", "err-2", cookie_path=str(cookie_path), now=base)
+
+    paused = guard.should_skip_start("task-a", cookie_path=str(cookie_path), now=base)
+    assert paused.skip is True
+
+    cookie_path.write_text('{"updated": true}', encoding="utf-8")
+
+    recovered = guard.should_skip_start(
+        "task-a",
+        cookie_path=str(cookie_path),
+        now=base + timedelta(minutes=1),
+    )
+    assert recovered.skip is False


### PR DESCRIPTION
Problem
- When cookies/session expires or risk-control is triggered, tasks can keep retrying and hammering Goofish.

What changed
- Add a task-level failure circuit breaker (FailureGuard): after N consecutive failures, pause the task for a while instead of retrying forever.
- While paused, send at most 1 notification per day.
- Automatically recover when the cookies/state file is updated (mtime change).
- Detect redirect to `passport.goofish.com/mini_login` and treat it as a login-required failure (stop pointless rotation retries).
- Also check the pause state before starting a task process (skip start + daily reminder).

Config (optional)
- `TASK_FAILURE_THRESHOLD` (default: 3)
- `TASK_FAILURE_PAUSE_SECONDS` (default: 86400)
- `TASK_FAILURE_GUARD_PATH` (default: `logs/task-failure-guard.json`)

Tests
- `pytest` (adds coverage for open-circuit, daily rate-limit, auto-recover)