### PR TITLE
fix: Telegram通知配置API保存后集成页面及显示未配置

### DIFF
--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -12,7 +12,7 @@ from src.api.dependencies import get_process_service
 from src.infrastructure.config.env_manager import env_manager
 from src.infrastructure.config.settings import (
     AISettings,
-    notification_settings,
+    NotificationSettings,
     reload_settings,
     scraper_settings,
 )
@@ -173,6 +173,7 @@ async def get_system_status(
         if process and process.returncode is None
     ]
 
+    notification_settings = NotificationSettings()
     return {
         "ai_configured": ai_settings.is_configured(),
         "notification_configured": notification_settings.has_any_notification_enabled(),


### PR DESCRIPTION
修多：修夝api/settings/status使用模块级单例notification_settings，改为在函数内创建新NotificationSettings实例从当前.env文件读取最新配置。

解决issue #352

-generated-with-claude-code-https://claude.ai/code