### PR TITLE
fix(docker): 修复容器中 Playwright 浏览器路径与权限不一致导致启动失败

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 # 新增环境变量，用于区分Docker环境和本地环境
 ENV RUNNING_IN_DOCKER=true
-# 告知 Playwright 在哪里找到浏览器
-ENV PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright
+# 告知 Playwright 在哪里找到浏览器（使用独立目录，避免 root/appuser 主目录差异）
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 # 设置时区为中国时区
 ENV TZ=Asia/Shanghai
 
@@ -56,11 +56,9 @@ RUN apt-get update \
         netcat-openbsd \
         telnet \
     && playwright install-deps chromium \
+    && playwright install chromium \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# 从 builder 阶段复制预先下载好的浏览器
-COPY --from=builder /root/.cache/ms-playwright /root/.cache/ms-playwright
 
 # 复制前端构建产物到 /app/dist
 COPY --from=frontend-builder /web-ui/dist /app/dist
@@ -74,7 +72,7 @@ EXPOSE 8000
 
 # 创建非 root 用户并设置目录权限
 RUN useradd -m -s /bin/bash appuser && \
-    chown -R appuser:appuser /app
+    chown -R appuser:appuser /app /ms-playwright
 
 # 切换到非 root 用户
 USER appuser


### PR DESCRIPTION
### Motivation
- 日志显示容器运行时无法找到 Playwright Chromium 可执行文件，错误为 `BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...`，其根因是构建期/运行期浏览器缓存路径与运行用户不一致且运行镜像未确保浏览器二进制可用。 
- 目标是确保运行镜像内存在与当前 Playwright 匹配的 Chromium 可执行文件，并且运行用户 `appuser` 可访问，避免启动失败与版本漂移问题。

### Description
- 将环境变量 `PLAYWRIGHT_BROWSERS_PATH` 改为固定全局路径 `/ms-playwright`，避免依赖 `/root` 或其它用户主目录。 
- 在最终运行镜像阶段执行 `playwright install chromium`，确保浏览器二进制在运行层被安装并与 Playwright 版本匹配。 
- 移除从 builder 阶段复制 `/root/.cache/ms-playwright` 的操作，改为在运行镜像中本地安装浏览器并对 `/ms-playwright` 目录执行 `chown` 使 `appuser` 可读写。 
- 保留将虚拟环境复制到运行镜像以确保 `playwright` CLI 可用并维持原有运行时结构。

### Testing
- 运行代码扫描与文件检查（例如 `rg -n "playwright|BrowserType.launch|chromium|ms-playwright|install"` 与查看 `Dockerfile`/`src/scraper.py`），确认引用点与修复位置，检查通过。 
- 尝试运行 `docker compose -f docker-compose.dev.yaml config` 以验证 compose 配置，但本环境没有 Docker CLI（`command not found: docker`），因此未能在本地构建或启动镜像。 
- 尝试访问外部 Playwright 文档以核对建议命令但请求被代理返回 403，无法在线验证浏览器安装细节；建议在 CI 或目标主机执行 `docker compose build --no-cache app` 和 `docker compose up -d` 并触发一次任务以完成端到端验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa8dd032ec83279e16b241fd4ad608)