### PR TITLE
refactor(build): 统一前端构建产物路径为根目录 dist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,7 @@ __pycache__
 logs/
 jsonl/
 web-ui/node_modules
-web-ui/dist
+dist/
 .git
 .DS_Store
 task_images/

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# 复制前端构建产物到 /app/dist
-COPY --from=frontend-builder /web-ui/dist /app/dist
+# Vite 输出到仓库根目录 /dist，而不是 /web-ui/dist
+COPY --from=frontend-builder /dist /app/dist
 
 # 复制应用代码
 # .dockerignore 文件会处理排除项-m

--- a/start.sh
+++ b/start.sh
@@ -324,18 +324,18 @@ fi
 echo "正在构建前端..."
 npm run build
 
+cd "$SCRIPT_DIR"
+
 if [ ! -d "dist" ]; then
     echo -e "${RED}✗ 错误: 前端构建失败，dist 目录未生成${NC}"
     exit 1
 fi
 
-echo -e "${GREEN}✓ 前端构建完成${NC}"
+echo -e "${GREEN}✓ 前端构建完成，产物已输出到项目根目录 dist/${NC}"
 
-# 4. 复制构建产物到项目根目录
-echo -e "\n${YELLOW}[5/6] 复制构建产物...${NC}"
-cd "$SCRIPT_DIR"
-cp -r web-ui/dist ./
-echo -e "${GREEN}✓ 构建产物已复制到项目根目录${NC}"
+# 4. 校验构建产物
+echo -e "\n${YELLOW}[5/6] 校验构建产物...${NC}"
+echo -e "${GREEN}✓ 已确认构建产物位于项目根目录 dist/${NC}"
 
 # 5. 启动后端服务
 echo -e "\n${YELLOW}[6/6] 启动后端服务...${NC}"

--- a/tests/test_frontend_build_paths.py
+++ b/tests/test_frontend_build_paths.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROOT_DIST = "/dist"
+
+
+def read_repo_file(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_frontend_build_output_path_is_consistent_across_configs():
+    vite_config = read_repo_file("web-ui/vite.config.ts")
+    dockerfile = read_repo_file("Dockerfile")
+    frontend_dockerfile = read_repo_file("web-ui/Dockerfile")
+    dockerignore = read_repo_file(".dockerignore")
+    start_script = read_repo_file("start.sh")
+    dockerignore_lines = dockerignore.splitlines()
+
+    assert "path.resolve(__dirname, '../dist')" in vite_config
+    assert (
+        f"COPY --from=frontend-builder {ROOT_DIST} /app/dist" in dockerfile
+    ), "Docker multi-stage copy must use the Vite build output path."
+    assert (
+        f"COPY --from=builder {ROOT_DIST} /usr/share/nginx/html"
+        in frontend_dockerfile
+    ), "Frontend-only Docker build must use the Vite build output path."
+    assert "dist/" in dockerignore_lines
+    assert "web-ui/dist" not in dockerignore_lines
+    assert '[ ! -d "dist" ]' in start_script
+    assert "cp -r web-ui/dist ./" not in start_script

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -17,8 +17,8 @@ FROM nginx:alpine
 # Remove default nginx static assets
 RUN rm -rf /usr/share/nginx/html/*
 
-# Copy built assets from builder stage
-COPY --from=builder /app/dist /usr/share/nginx/html
+# Vite 输出到容器根目录 /dist，而不是 /app/dist
+COPY --from=builder /dist /usr/share/nginx/html
 
 # Copy custom nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- 修改 .dockerignore 将 web-ui/dist 替换为 dist/
- 更新主 Dockerfile 中前端产物复制路径从 /web-ui/dist 到 /dist
- 更新 web-ui/Dockerfile 注释说明 Vite 输出到容器根目录 /dist
- 修改 start.sh 脚本中的构建产物检查和复制逻辑
- 添加测试文件验证前端构建路径配置的一致性