### PR TITLE
feat(ui): 添加 cron 定时规则预设选择器

### DIFF
--- a/web-ui/src/components/tasks/TaskForm.vue
+++ b/web-ui/src/components/tasks/TaskForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
+import { ref, watchEffect, computed } from 'vue'
 import type { Task, TaskGenerateRequest } from '@/types/task.d.ts'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -7,6 +7,7 @@ import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from '@/components/ui/toast'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import TaskRegionSelector from '@/components/tasks/TaskRegionSelector.vue'
 
 type FormMode = 'create' | 'edit'
@@ -27,6 +28,39 @@ const emit = defineEmits<{
 
 const form = ref<any>({})
 const keywordRulesInput = ref('')
+const cronMode = ref<'preset' | 'custom'>('preset')
+
+// 常用 cron 预设选项
+const cronPresets = [
+  { value: '', label: '不定时（手动运行）' },
+  { value: '*/5 * * * *', label: '每 5 分钟' },
+  { value: '*/15 * * * *', label: '每 15 分钟' },
+  { value: '*/30 * * * *', label: '每 30 分钟' },
+  { value: '0 * * * *', label: '每小时' },
+  { value: '0 */2 * * *', label: '每 2 小时' },
+  { value: '0 */6 * * *', label: '每 6 小时' },
+  { value: '0 8 * * *', label: '每天 8:00' },
+  { value: '0 12 * * *', label: '每天 12:00' },
+  { value: '0 18 * * *', label: '每天 18:00' },
+  { value: '0 20 * * *', label: '每天 20:00' },
+  { value: '0 8,12,18 * * *', label: '每天 8:00/12:00/18:00' },
+  { value: '0 9 * * 1-5', label: '工作日 9:00' },
+  { value: '0 10 * * 6,0', label: '周末 10:00' },
+]
+
+// 判断 cron 值是否为预设值
+function isPresetCronValue(value: string): boolean {
+  return cronPresets.some(p => p.value === value)
+}
+
+// 判断当前 cron 是否为预设值
+const isPresetCron = computed(() => isPresetCronValue(form.value.cron))
+
+// 预设选择的值
+const presetCronValue = computed({
+  get: () => isPresetCron.value ? (form.value.cron || '') : '',
+  set: (val: string) => { form.value.cron = val },
+})
 const accountStrategyOptions = [
   { value: 'auto', label: '自动选择', description: '优先使用默认登录态；无默认时使用账号池。' },
   { value: 'fixed', label: '固定账号', description: '当前任务始终绑定一个指定账号。' },
@@ -72,6 +106,9 @@ watchEffect(() => {
       decision_mode: defaultValues.decision_mode || props.initialData.decision_mode || 'ai',
     }
     keywordRulesInput.value = (defaultValues.keyword_rules || props.initialData.keyword_rules || []).join('\n')
+    // 编辑模式下，根据 cron 值判断模式
+    const cronVal = defaultValues.cron ?? props.initialData.cron ?? ''
+    cronMode.value = isPresetCronValue(cronVal) ? 'preset' : 'custom'
   } else {
     form.value = {
       task_name: '',
@@ -104,6 +141,9 @@ watchEffect(() => {
     if (defaultValues.keyword_rules && defaultValues.keyword_rules.length > 0) {
       keywordRulesInput.value = defaultValues.keyword_rules.join('\n')
     }
+    // 创建模式下，根据默认值判断模式
+    const cronVal = defaultValues.cron ?? ''
+    cronMode.value = isPresetCronValue(cronVal) ? 'preset' : 'custom'
   }
 })
 
@@ -255,7 +295,36 @@ function handleSubmit() {
       </div>
       <div class="grid grid-cols-4 items-center gap-4">
         <Label for="cron" class="text-right">定时规则</Label>
-        <Input id="cron" v-model="form.cron as any" class="col-span-3" placeholder="分 时 日 月 周 (例如: 0 8 * * *)" />
+        <div class="col-span-3 space-y-2">
+          <Tabs v-model="cronMode" class="w-full">
+            <TabsList class="grid w-full grid-cols-2">
+              <TabsTrigger value="preset">预设</TabsTrigger>
+              <TabsTrigger value="custom">自定义</TabsTrigger>
+            </TabsList>
+            <TabsContent value="preset">
+              <Select v-model="presetCronValue">
+                <SelectTrigger>
+                  <SelectValue placeholder="选择定时规则" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem v-for="preset in cronPresets" :key="preset.value" :value="preset.value">
+                    {{ preset.label }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </TabsContent>
+            <TabsContent value="custom">
+              <Input
+                id="cron"
+                v-model="form.cron"
+                placeholder="分 时 日 月 周 (例如: 0 8 * * *)"
+              />
+              <p class="text-xs text-gray-500 mt-1">
+                Cron 格式：分(0-59) 时(0-23) 日(1-31) 月(1-12) 周(0-6)
+              </p>
+            </TabsContent>
+          </Tabs>
+        </div>
       </div>
       <div class="grid grid-cols-4 items-center gap-4">
         <Label class="text-right">账号策略</Label>


### PR DESCRIPTION
- 新增预设/自定义两种模式切换
- 提供常用 cron 表达式预设选项（每5分钟/每小时/每天等）
- 编辑任务时自动识别 cron 模式
- 保留手动输入自定义 cron 的能力
- 自定义模式下显示 cron 格式提示