### PR TITLE
feat(tasks): 优化任务表单的账号策略配置功能

### DIFF
--- a/web-ui/src/components/tasks/TaskForm.vue
+++ b/web-ui/src/components/tasks/TaskForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watchEffect, computed } from 'vue'
+import { ref, watch, computed } from 'vue'
 import type { Task, TaskGenerateRequest } from '@/types/task.d.ts'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -13,6 +13,7 @@ import TaskRegionSelector from '@/components/tasks/TaskRegionSelector.vue'
 type FormMode = 'create' | 'edit'
 type EmittedData = TaskGenerateRequest | Partial<Task>
 const AUTO_ACCOUNT_VALUE = '__auto__'
+const EMPTY_CRON_VALUE = '__manual__'
 
 const props = defineProps<{
   mode: FormMode
@@ -27,12 +28,14 @@ const emit = defineEmits<{
 }>()
 
 const form = ref<any>({})
+const accountStrategy = ref<'auto' | 'fixed' | 'rotate'>('auto')
+const selectedAccountStateFile = ref(AUTO_ACCOUNT_VALUE)
 const keywordRulesInput = ref('')
 const cronMode = ref<'preset' | 'custom'>('preset')
 
 // 常用 cron 预设选项
 const cronPresets = [
-  { value: '', label: '不定时（手动运行）' },
+  { value: EMPTY_CRON_VALUE, label: '不定时（手动运行）' },
   { value: '*/5 * * * *', label: '每 5 分钟' },
   { value: '*/15 * * * *', label: '每 15 分钟' },
   { value: '*/30 * * * *', label: '每 30 分钟' },
@@ -50,6 +53,7 @@ const cronPresets = [
 
 // 判断 cron 值是否为预设值
 function isPresetCronValue(value: string): boolean {
+  if (!value) return true
   return cronPresets.some(p => p.value === value)
 }
 
@@ -58,8 +62,11 @@ const isPresetCron = computed(() => isPresetCronValue(form.value.cron))
 
 // 预设选择的值
 const presetCronValue = computed({
-  get: () => isPresetCron.value ? (form.value.cron || '') : '',
-  set: (val: string) => { form.value.cron = val },
+  get: () => {
+    if (!isPresetCron.value) return EMPTY_CRON_VALUE
+    return form.value.cron || EMPTY_CRON_VALUE
+  },
+  set: (val: string) => { form.value.cron = val === EMPTY_CRON_VALUE ? '' : val },
 })
 const accountStrategyOptions = [
   { value: 'auto', label: '自动选择', description: '优先使用默认登录态；无默认时使用账号池。' },
@@ -84,7 +91,7 @@ function parseKeywordText(text: string): string[] {
   return deduped
 }
 
-watchEffect(() => {
+watch(() => [props.mode, props.initialData, props.defaultValues, props.defaultAccount], () => {
   const defaultValues = props.defaultValues || {}
   if (props.mode === 'edit' && props.initialData) {
     form.value = {
@@ -145,7 +152,34 @@ watchEffect(() => {
     const cronVal = defaultValues.cron ?? ''
     cronMode.value = isPresetCronValue(cronVal) ? 'preset' : 'custom'
   }
+
+  accountStrategy.value = form.value.account_strategy || (props.defaultAccount ? 'fixed' : 'auto')
+  selectedAccountStateFile.value =
+    form.value.account_state_file || props.defaultAccount || AUTO_ACCOUNT_VALUE
+}, { immediate: true, deep: true })
+
+watch(accountStrategy, (value) => {
+  form.value.account_strategy = value
+  if (value === 'fixed') {
+    form.value.account_state_file = selectedAccountStateFile.value || props.defaultAccount || AUTO_ACCOUNT_VALUE
+    return
+  }
+  form.value.account_state_file = null
 })
+
+watch(selectedAccountStateFile, (value) => {
+  if (accountStrategy.value !== 'fixed') return
+  form.value.account_state_file = value || props.defaultAccount || AUTO_ACCOUNT_VALUE
+})
+
+function handleAccountStrategyChange(event: Event) {
+  const value = (event.target as HTMLSelectElement).value as 'auto' | 'fixed' | 'rotate'
+  accountStrategy.value = value
+}
+
+function handleAccountStateFileChange(event: Event) {
+  selectedAccountStateFile.value = (event.target as HTMLSelectElement).value || AUTO_ACCOUNT_VALUE
+}
 
 function handleSubmit() {
   if (!form.value.task_name || !form.value.keyword) {
@@ -179,9 +213,10 @@ function handleSubmit() {
 
   // Filter out fields that shouldn't be sent in update requests
   const { id, is_running, ...submitData } = form.value as any
-  const accountStrategy = submitData.account_strategy || 'auto'
-  if (accountStrategy === 'fixed') {
-    if (!submitData.account_state_file || submitData.account_state_file === AUTO_ACCOUNT_VALUE) {
+  const currentAccountStrategy = accountStrategy.value || 'auto'
+  if (currentAccountStrategy === 'fixed') {
+    const currentAccountStateFile = selectedAccountStateFile.value || AUTO_ACCOUNT_VALUE
+    if (currentAccountStateFile === AUTO_ACCOUNT_VALUE) {
       toast({
         title: '账号策略不完整',
         description: '固定账号模式下必须选择一个账号。',
@@ -189,6 +224,7 @@ function handleSubmit() {
       })
       return
     }
+    submitData.account_state_file = currentAccountStateFile
   } else {
     submitData.account_state_file = null
   }
@@ -208,7 +244,7 @@ function handleSubmit() {
   }
 
   submitData.decision_mode = decisionMode
-  submitData.account_strategy = accountStrategy
+  submitData.account_strategy = currentAccountStrategy
   submitData.analyze_images = submitData.analyze_images !== false
   submitData.keyword_rules = decisionMode === 'keyword' ? keywordRules : []
   if (decisionMode === 'keyword' && !submitData.description) {
@@ -329,34 +365,33 @@ function handleSubmit() {
       <div class="grid grid-cols-4 items-center gap-4">
         <Label class="text-right">账号策略</Label>
         <div class="col-span-3 space-y-2">
-          <Select v-model="form.account_strategy">
-            <SelectTrigger>
-              <SelectValue placeholder="请选择账号策略" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem v-for="option in accountStrategyOptions" :key="option.value" :value="option.value">
-                {{ option.label }}
-              </SelectItem>
-            </SelectContent>
-          </Select>
+          <select
+            :value="accountStrategy"
+            class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            @change="handleAccountStrategyChange"
+          >
+            <option v-for="option in accountStrategyOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
+          </select>
           <p class="text-xs text-gray-500">
-            {{ accountStrategyOptions.find((option) => option.value === form.account_strategy)?.description }}
+            {{ accountStrategyOptions.find((option) => option.value === accountStrategy)?.description }}
           </p>
         </div>
       </div>
-      <div v-if="form.account_strategy === 'fixed'" class="grid grid-cols-4 items-center gap-4">
+      <div v-if="accountStrategy === 'fixed'" class="grid grid-cols-4 items-center gap-4">
         <Label class="text-right">指定账号</Label>
         <div class="col-span-3">
-          <Select v-model="form.account_state_file">
-            <SelectTrigger>
-              <SelectValue placeholder="请选择账号" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem v-for="account in accountOptions || []" :key="account.path" :value="account.path">
-                {{ account.name }}
-              </SelectItem>
-            </SelectContent>
-          </Select>
+          <select
+            :value="selectedAccountStateFile"
+            class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            @change="handleAccountStateFileChange"
+          >
+            <option :value="AUTO_ACCOUNT_VALUE">请选择账号</option>
+            <option v-for="account in accountOptions || []" :key="account.path" :value="account.path">
+              {{ account.name }}
+            </option>
+          </select>
         </div>
       </div>
       <div class="grid grid-cols-4 items-center gap-4">


### PR DESCRIPTION
- 将 watchEffect 替换为 watch，提升响应式监听性能
- 新增账号策略选择功能，支持自动、固定、轮换三种模式
- 添加手动运行定时任务的空值处理逻辑
- 实现账号状态文件的动态绑定和验证
- 更新表单提交逻辑以正确处理账号策略数据
- 使用原生 select 组件替换 UI 库组件，简化代码结构