### PR TITLE
refactor(ai): 将AI客户端从Chat Completions API迁移到Responses API

### DIFF
--- a/src/ai_handler.py
+++ b/src/ai_handler.py
@@ -35,8 +35,9 @@ from src.services.ai_response_parser import (
     parse_ai_response_json,
 )
 from src.services.ai_request_compat import (
-    add_json_response_format,
-    is_response_format_unsupported_error,
+    add_json_text_format,
+    build_responses_input,
+    is_json_output_unsupported_error,
 )
 from src.services.notification_service import build_notification_service
 from src.utils import convert_goofish_link, retry_on_failure
@@ -323,7 +324,7 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
     except Exception as e:
         safe_print(f"   [日志] 保存AI分析日志时出错: {e}")
 
-    # 增强的AI调用，包含更严格的格式控制和重试机制
+    # 增强的AI调用，包含更严格的结构化输出控制和重试机制
     max_retries = 3
     use_response_format = ENABLE_RESPONSE_FORMAT
     for attempt in range(max_retries):
@@ -333,19 +334,19 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
 
             from src.config import get_ai_request_params
             
-            # 构建请求参数，根据ENABLE_RESPONSE_FORMAT决定是否使用response_format
+            # 构建请求参数，根据ENABLE_RESPONSE_FORMAT决定是否启用结构化 JSON 输出
             request_params = {
                 "model": MODEL_NAME,
-                "messages": messages,
+                "input": build_responses_input(messages),
                 "temperature": current_temperature,
-                "max_tokens": 4000
+                "max_output_tokens": 4000,
             }
-            request_params = add_json_response_format(
+            request_params = add_json_text_format(
                 request_params,
                 use_response_format,
             )
             
-            response = await client.chat.completions.create(
+            response = await client.responses.create(
                 **get_ai_request_params(**request_params)
             )
             ai_response_content = extract_ai_response_content(response)
@@ -382,10 +383,10 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
                 raise e
 
         except Exception as e:
-            if use_response_format and is_response_format_unsupported_error(e):
+            if use_response_format and is_json_output_unsupported_error(e):
                 use_response_format = False
                 safe_print(
-                    "   [AI分析] 当前模型不支持 response_format，后续重试将自动禁用该参数。"
+                    "   [AI分析] 当前模型不支持结构化 JSON 输出，后续重试将自动禁用该参数。"
                 )
             safe_print(f"   [AI分析] 第{attempt + 1}次尝试AI调用失败: {e}")
             if attempt < max_retries - 1:

--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -15,6 +15,8 @@ from src.infrastructure.config.settings import (
     reload_settings,
     scraper_settings,
 )
+from src.services.ai_request_compat import build_responses_input
+from src.services.ai_response_parser import extract_ai_response_content
 from src.services.notification_config_service import (
     NotificationSettingsValidationError,
     build_configured_channels,
@@ -29,6 +31,8 @@ from src.services.process_service import ProcessService
 
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
+AI_TEST_PROMPT = "Reply with OK only."
+AI_TEST_MAX_OUTPUT_TOKENS = 32
 
 
 def _reload_env() -> None:
@@ -287,18 +291,18 @@ async def test_ai_settings(settings: dict):
 
         model_name = settings.get("OPENAI_MODEL_NAME", "")
         client = OpenAI(**client_params)
-        response = client.chat.completions.create(
+        response = client.responses.create(
             model=model_name,
-            messages=[
-                {"role": "user", "content": "Hello, this is a test message."}
-            ],
-            max_tokens=10,
+            input=build_responses_input(
+                [{"role": "user", "content": AI_TEST_PROMPT}]
+            ),
+            max_output_tokens=AI_TEST_MAX_OUTPUT_TOKENS,
         )
 
         return {
             "success": True,
             "message": "AI模型连接测试成功！",
-            "response": response.choices[0].message.content if response.choices else "No response",
+            "response": extract_ai_response_content(response),
         }
     except Exception as exc:
         return {

--- a/src/config.py
+++ b/src/config.py
@@ -93,8 +93,15 @@ def get_ai_request_params(**kwargs):
     if ENABLE_THINKING:
         kwargs["extra_body"] = {"enable_thinking": False}
     
-    # 如果禁用response_format，则移除该参数
-    if not ENABLE_RESPONSE_FORMAT and "response_format" in kwargs:
-        del kwargs["response_format"]
+    # 如果禁用结构化输出，则移除 text.format 配置
+    if not ENABLE_RESPONSE_FORMAT and "text" in kwargs:
+        text_config = kwargs.get("text")
+        if isinstance(text_config, dict):
+            text_config = dict(text_config)
+            text_config.pop("format", None)
+            if text_config:
+                kwargs["text"] = text_config
+            else:
+                del kwargs["text"]
     
     return kwargs

--- a/src/infrastructure/external/ai_client.py
+++ b/src/infrastructure/external/ai_client.py
@@ -16,9 +16,11 @@ from src.ai_message_builder import (
 from src.infrastructure.config.settings import AISettings
 from src.infrastructure.config.env_manager import env_manager
 from src.services.ai_request_compat import (
-    add_json_response_format,
-    is_response_format_unsupported_error,
+    add_json_text_format,
+    build_responses_input,
+    is_json_output_unsupported_error,
 )
+from src.services.ai_response_parser import extract_ai_response_content
 
 
 class AIClient:
@@ -127,11 +129,11 @@ class AIClient:
         for attempt in range(max_attempts):
             request_params = {
                 "model": self.settings.model_name,
-                "messages": messages,
+                "input": build_responses_input(messages),
                 "temperature": 0.1,
-                "max_tokens": 4000
+                "max_output_tokens": 4000,
             }
-            request_params = add_json_response_format(
+            request_params = add_json_text_format(
                 request_params,
                 use_response_format,
             )
@@ -140,18 +142,16 @@ class AIClient:
                 request_params["extra_body"] = {"enable_thinking": False}
 
             try:
-                response = await self.client.chat.completions.create(**request_params)
+                response = await self.client.responses.create(**request_params)
             except Exception as exc:
-                if use_response_format and is_response_format_unsupported_error(exc):
+                if use_response_format and is_json_output_unsupported_error(exc):
                     use_response_format = False
-                    print("当前模型不支持 response_format，正在自动重试并移除该参数")
+                    print("当前模型不支持结构化 JSON 输出，正在自动重试并移除该参数")
                     if attempt < max_attempts - 1:
                         continue
                 raise
 
-            if hasattr(response, 'choices'):
-                return response.choices[0].message.content
-            return response
+            return extract_ai_response_content(response)
 
         raise RuntimeError("AI 调用在兼容性重试后仍未返回结果")
 

--- a/src/prompt_utils.py
+++ b/src/prompt_utils.py
@@ -6,6 +6,8 @@ from typing import Awaitable, Callable, Optional
 import aiofiles
 
 from src.infrastructure.external.ai_client import AIClient
+from src.services.ai_request_compat import build_responses_input
+from src.services.ai_response_parser import extract_ai_response_content
 
 # The meta-prompt to instruct the AI
 META_PROMPT_TEMPLATE = """
@@ -81,19 +83,14 @@ async def generate_criteria(
     try:
         request_params = {
             "model": ai_client.settings.model_name,
-            "messages": [{"role": "user", "content": prompt}],
+            "input": build_responses_input([{"role": "user", "content": prompt}]),
             "temperature": 0.5,
         }
         if ai_client.settings.enable_thinking:
             request_params["extra_body"] = {"enable_thinking": False}
 
-        response = await ai_client.client.chat.completions.create(**request_params)
-        # 兼容不同API响应格式，检查response是否为字符串
-        if hasattr(response, 'choices'):
-            generated_text = response.choices[0].message.content
-        else:
-            # 如果response是字符串，则直接使用
-            generated_text = response
+        response = await ai_client.client.responses.create(**request_params)
+        generated_text = extract_ai_response_content(response)
         print("AI已成功生成内容。")
         
         # 处理content可能为None或空字符串的情况

--- a/src/services/ai_request_compat.py
+++ b/src/services/ai_request_compat.py
@@ -1,27 +1,97 @@
 """AI 请求兼容性辅助逻辑。"""
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, List
 
 
-UNSUPPORTED_RESPONSE_FORMAT_MARKERS = (
-    "response_format.type",
-    "json_object",
+INPUT_TEXT_TYPE = "input_text"
+INPUT_IMAGE_TYPE = "input_image"
+IMAGE_DETAIL_AUTO = "auto"
+JSON_OUTPUT_TYPE = "json_object"
+UNSUPPORTED_JSON_OUTPUT_MARKERS = (
     "not supported by this model",
+    "json_object",
+    "json_schema",
+    "text.format",
+    "response_format.type",
 )
 
 
-def add_json_response_format(
+def build_responses_input(messages: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """将 Chat Completions 风格的消息转换为 Responses API 输入。"""
+    input_items: List[Dict[str, Any]] = []
+    for message in messages:
+        role = str(message.get("role") or "user")
+        input_items.append(
+            {
+                "role": role,
+                "content": _build_input_content(message.get("content")),
+            }
+        )
+    return input_items
+
+
+def add_json_text_format(
     request_params: Dict[str, Any],
     enabled: bool,
 ) -> Dict[str, Any]:
-    """按需附加结构化输出参数，避免直接修改原始字典。"""
+    """按需附加 Responses API 的结构化 JSON 输出参数。"""
     next_params = dict(request_params)
-    if enabled:
-        next_params["response_format"] = {"type": "json_object"}
+    if not enabled:
+        return next_params
+
+    text_config = dict(next_params.get("text") or {})
+    text_config["format"] = {"type": JSON_OUTPUT_TYPE}
+    next_params["text"] = text_config
     return next_params
 
 
-def is_response_format_unsupported_error(error: Exception) -> bool:
-    """识别模型不支持 response_format=json_object 的错误。"""
+def is_json_output_unsupported_error(error: Exception) -> bool:
+    """识别模型不支持结构化 JSON 输出参数的错误。"""
     message = str(error)
-    return all(marker in message for marker in UNSUPPORTED_RESPONSE_FORMAT_MARKERS)
+    return (
+        "not supported" in message.lower()
+        and any(marker in message for marker in UNSUPPORTED_JSON_OUTPUT_MARKERS)
+    )
+
+
+def _build_input_content(content: Any) -> List[Dict[str, Any]]:
+    if isinstance(content, str):
+        return [{"type": INPUT_TEXT_TYPE, "text": content}]
+    if not isinstance(content, list):
+        raise ValueError(f"AI消息内容类型不受支持: {type(content).__name__}")
+
+    return [_coerce_content_item(item) for item in content]
+
+
+def _coerce_content_item(item: Any) -> Dict[str, Any]:
+    if not isinstance(item, dict):
+        raise ValueError(f"AI消息片段类型不受支持: {type(item).__name__}")
+
+    item_type = item.get("type")
+    if item_type in {"text", INPUT_TEXT_TYPE}:
+        text = item.get("text")
+        if not isinstance(text, str):
+            raise ValueError("文本消息片段缺少 text 字段。")
+        return {"type": INPUT_TEXT_TYPE, "text": text}
+
+    if item_type in {"image_url", INPUT_IMAGE_TYPE}:
+        return _build_image_input_item(item)
+
+    raise ValueError(f"不支持的 AI 消息片段类型: {item_type}")
+
+
+def _build_image_input_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    raw_image = item.get("image_url")
+    if isinstance(raw_image, dict):
+        image_url = raw_image.get("url")
+    else:
+        image_url = raw_image
+
+    if not isinstance(image_url, str) or not image_url.strip():
+        raise ValueError("图片消息片段缺少有效的 image_url。")
+
+    return {
+        "type": INPUT_IMAGE_TYPE,
+        "image_url": image_url,
+        "detail": item.get("detail", IMAGE_DETAIL_AUTO),
+    }

--- a/tests/unit/test_ai_client.py
+++ b/tests/unit/test_ai_client.py
@@ -2,12 +2,12 @@ import asyncio
 from types import SimpleNamespace
 
 from src.infrastructure.external.ai_client import AIClient
+from src.services.ai_request_compat import build_responses_input
 
 
 def _build_fake_client(create_impl):
-    completions = SimpleNamespace(create=create_impl)
-    chat = SimpleNamespace(completions=completions)
-    return SimpleNamespace(chat=chat)
+    responses = SimpleNamespace(create=create_impl)
+    return SimpleNamespace(responses=responses)
 
 
 def test_build_messages_without_images_uses_text_only_content():
@@ -41,7 +41,35 @@ def test_build_messages_with_images_uses_multimodal_content(monkeypatch):
     assert content[-1]["type"] == "text"
 
 
-def test_call_ai_retries_without_response_format_when_model_rejects_it():
+def test_build_responses_input_converts_multimodal_messages():
+    result = build_responses_input(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,ZmFrZQ=="}},
+                    {"type": "text", "text": "hello"},
+                ],
+            }
+        ]
+    )
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/jpeg;base64,ZmFrZQ==",
+                    "detail": "auto",
+                },
+                {"type": "input_text", "text": "hello"},
+            ],
+        }
+    ]
+
+
+def test_call_ai_retries_without_structured_output_when_model_rejects_it():
     client = AIClient.__new__(AIClient)
     client.settings = SimpleNamespace(
         model_name="fake-model",
@@ -55,18 +83,17 @@ def test_call_ai_retries_without_response_format_when_model_rejects_it():
         if len(request_history) == 1:
             raise Exception(
                 "Error code: 400 - {'error': {'code': 'InvalidParameter', "
-                "'message': 'The parameter `response_format.type` specified in "
+                "'message': 'The parameter `text.format.type` specified in "
                 "the request are not valid: `json_object` is not supported by "
-                "this model.', 'param': 'response_format.type'}}"
+                "this model.', 'param': 'text.format.type'}}"
             )
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content='{"ok":true}'))]
-        )
+        return SimpleNamespace(output_text='{"ok":true}')
 
     client.client = _build_fake_client(fake_create)
 
     response = asyncio.run(client._call_ai([{"role": "user", "content": "hi"}]))
 
     assert response == '{"ok":true}'
-    assert "response_format" in request_history[0]
-    assert "response_format" not in request_history[1]
+    assert request_history[0]["input"][0]["content"][0]["type"] == "input_text"
+    assert request_history[0]["text"]["format"]["type"] == "json_object"
+    assert "text" not in request_history[1]

--- a/tests/unit/test_ai_handler_analysis.py
+++ b/tests/unit/test_ai_handler_analysis.py
@@ -8,9 +8,8 @@ import src.config as app_config
 
 
 def _build_fake_client(create_impl):
-    completions = SimpleNamespace(create=create_impl)
-    chat = SimpleNamespace(completions=completions)
-    return SimpleNamespace(chat=chat)
+    responses = SimpleNamespace(create=create_impl)
+    return SimpleNamespace(responses=responses)
 
 
 def test_get_ai_analysis_stops_after_internal_retries_when_content_is_none(
@@ -21,9 +20,7 @@ def test_get_ai_analysis_stops_after_internal_retries_when_content_is_none(
 
     async def fake_create(**_kwargs):
         call_count["value"] += 1
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content=None))]
-        )
+        return SimpleNamespace(output_text="")
 
     monkeypatch.setattr(ai_handler, "client", _build_fake_client(fake_create))
     monkeypatch.setattr(ai_handler, "MODEL_NAME", "fake-model")
@@ -49,16 +46,10 @@ def test_get_ai_analysis_returns_parsed_json(monkeypatch, tmp_path):
     async def fake_create(**_kwargs):
         call_count["value"] += 1
         return SimpleNamespace(
-            choices=[
-                SimpleNamespace(
-                    message=SimpleNamespace(
-                        content=(
-                            '{"prompt_version":"v1","is_recommended":true,'
-                            '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
-                        )
-                    )
-                )
-            ]
+            output_text=(
+                '{"prompt_version":"v1","is_recommended":true,'
+                '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
+            )
         )
 
     monkeypatch.setattr(ai_handler, "client", _build_fake_client(fake_create))
@@ -78,7 +69,7 @@ def test_get_ai_analysis_returns_parsed_json(monkeypatch, tmp_path):
     assert call_count["value"] == 1
 
 
-def test_get_ai_analysis_retries_without_response_format_when_model_rejects_it(
+def test_get_ai_analysis_retries_without_structured_output_when_model_rejects_it(
     monkeypatch, tmp_path
 ):
     monkeypatch.chdir(tmp_path)
@@ -89,21 +80,15 @@ def test_get_ai_analysis_retries_without_response_format_when_model_rejects_it(
         if len(request_history) == 1:
             raise Exception(
                 "Error code: 400 - {'error': {'code': 'InvalidParameter', "
-                "'message': 'The parameter `response_format.type` specified in "
+                "'message': 'The parameter `text.format.type` specified in "
                 "the request are not valid: `json_object` is not supported by "
-                "this model.', 'param': 'response_format.type'}}"
+                "this model.', 'param': 'text.format.type'}}"
             )
         return SimpleNamespace(
-            choices=[
-                SimpleNamespace(
-                    message=SimpleNamespace(
-                        content=(
-                            '{"prompt_version":"v1","is_recommended":true,'
-                            '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
-                        )
-                    )
-                )
-            ]
+            output_text=(
+                '{"prompt_version":"v1","is_recommended":true,'
+                '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
+            )
         )
 
     monkeypatch.setattr(ai_handler, "client", _build_fake_client(fake_create))
@@ -120,6 +105,7 @@ def test_get_ai_analysis_retries_without_response_format_when_model_rejects_it(
     )
 
     assert result["reason"] == "ok"
-    assert "response_format" in request_history[0]
-    assert "response_format" not in request_history[1]
+    assert request_history[0]["input"][0]["content"][0]["type"] == "input_text"
+    assert request_history[0]["text"]["format"]["type"] == "json_object"
+    assert "text" not in request_history[1]
     assert ai_handler.ENABLE_RESPONSE_FORMAT is True


### PR DESCRIPTION
- 替换add_json_response_format为add_json_text_format函数
- 添加build_responses_input函数用于构建Responses API输入格式
- 将messages参数改为input参数，并调整相关字段名称
- 修改API调用方式从chat.completions.create到responses.create
- 更新错误处理逻辑以适配新的JSON输出错误检测
- 添加AI响应内容提取函数extract_ai_response_content
- 重构测试用例以匹配新的API调用方式和参数结构