### PR TITLE
refactor(docker): 优化 Docker 构建配置和依赖管理

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,15 @@ __pycache__
 *.pyc
 .env
 .venv
+venv
+.idea
+.claude
+.serena
+.pytest_cache
 logs/
 jsonl/
 web-ui/node_modules
+web-ui/dist
 dist/
 .git
 .DS_Store
@@ -12,5 +18,7 @@ task_images/
 images/
 archive/
 tests/
+data/
+price_history/
 *.md
 !README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:22-alpine AS frontend-builder
 WORKDIR /web-ui
 COPY web-ui/package*.json ./
-RUN npm install
+RUN npm ci
 COPY web-ui/ .
 RUN npm run build
 
@@ -10,80 +10,52 @@ RUN npm run build
 FROM python:3.11-slim-bookworm AS builder
 
 # 设置环境变量以防止交互式提示
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:$PATH"
 
-# 创建虚拟环境
-ENV VIRTUAL_ENV=/opt/venv
+# 创建虚拟环境并安装 Python 运行时依赖
 RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-# 安装 Python 依赖到虚拟环境中 (使用国内镜像源加速)
-COPY requirements.txt .
-RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
-
-# 只下载 Playwright 的 Chromium 浏览器，系统依赖在下一阶段安装
-RUN playwright install chromium
+COPY requirements-runtime.txt .
+RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements-runtime.txt
 
 # Stage 3: Create the final, lean image
 FROM python:3.11-slim-bookworm
 
-# 设置工作目录和环境变量
 WORKDIR /app
-ENV VIRTUAL_ENV=/opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-ENV PYTHONUNBUFFERED=1
-# 新增环境变量，用于区分Docker环境和本地环境
-ENV RUNNING_IN_DOCKER=true
-# 告知 Playwright 在哪里找到浏览器（使用独立目录，避免 root/appuser 主目录差异）
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-# 设置时区为中国时区
-ENV TZ=Asia/Shanghai
+ENV DEBIAN_FRONTEND=noninteractive \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    RUNNING_IN_DOCKER=true \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    TZ=Asia/Shanghai
 
-# 从 builder 阶段复制虚拟环境，这样我们就可以使用 playwright 命令
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
-# 安装所有运行浏览器所需的系统级依赖（包括libzbar0）和网络诊断工具
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         tzdata \
         tini \
         libzbar0 \
-        curl \
-        wget \
-        iputils-ping \
-        dnsutils \
-        iproute2 \
-        netcat-openbsd \
-        telnet \
-    && playwright install-deps chromium \
-    && playwright install chromium \
+    && playwright install --with-deps --no-shell chromium \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Vite 输出到仓库根目录 /dist，而不是 /web-ui/dist
 COPY --from=frontend-builder /dist /app/dist
 
-# 复制应用代码
-# .dockerignore 文件会处理排除项-m
-COPY . .
+COPY src /app/src
+COPY spider_v2.py /app/spider_v2.py
+COPY prompts /app/prompts
+COPY static /app/static
+COPY config.json.example /app/config.json.example
 
-# 声明服务运行的端口
+RUN mkdir -p /app/data /app/state /app/logs /app/images /app/jsonl /app/price_history
+
 EXPOSE 8000
 
-# 创建非 root 用户并设置目录权限
-RUN useradd -m -s /bin/bash appuser && \
-    chown -R appuser:appuser /app /ms-playwright
-
-# 注意：运行时会挂载宿主机目录（prompts/jsonl/logs/images），
-# 在不同主机上这些目录可能由 root 或其他 UID 创建。
-# 若容器以内置 appuser 运行，常见场景会出现写入权限错误（Errno 13）。
-# 为保证开箱即用与历史行为一致，这里保持 root 运行主进程。
-# 如需非 root 运行，请在部署侧统一处理宿主机目录 UID/GID。
 USER root
 
-# 使用 tini 作为 init，负责回收孤儿子进程
 ENTRYPOINT ["tini", "--"]
 
-# 容器启动时执行的命令
-# 使用新架构的启动方式
 CMD ["python", "-m", "src.app"]

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,0 +1,15 @@
+python-dotenv
+playwright
+requests
+openai
+fastapi
+uvicorn[standard]
+pydantic-settings
+jinja2
+aiofiles
+python-socks
+apscheduler
+httpx[socks]
+Pillow
+pyzbar
+qrcode

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -551,8 +551,7 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
             if LOGIN_IS_EDGE:
                 launch_kwargs["channel"] = "msedge"
             else:
-                if not RUNNING_IN_DOCKER:
-                    launch_kwargs["channel"] = "chrome"
+                launch_kwargs["channel"] = "chromium" if RUNNING_IN_DOCKER else "chrome"
 
             browser = await p.chromium.launch(**launch_kwargs)
 


### PR DESCRIPTION
- 更新 .dockerignore 文件，添加更多忽略路径如 venv、.idea、.claude 等开发文件
- 将前端构建命令从 npm install 改为 npm ci 以确保依赖一致性
- 重构 Dockerfile 中的环境变量设置，合并多行 ENV 指令提高可读性
- 更改 Python 依赖安装方式，使用 requirements-runtime.txt 分离运行时依赖
- 优化 Playwright 浏览器安装命令，使用 --with-deps 参数简化安装流程
- 调整文件复制策略，改为精确复制特定目录和文件而非整个项目
- 在 Dockerfile 中添加必要的目录创建指令
- 修改浏览器启动逻辑，统一 Docker 环境下使用 chromium 通道