### PR TITLE
fix(ai): fallback when gateway does not support `temperature` parameter

### DIFF
--- a/src/ai_handler.py
+++ b/src/ai_handler.py
@@ -38,6 +38,8 @@ from src.services.ai_request_compat import (
     add_json_text_format,
     build_responses_input,
     is_json_output_unsupported_error,
+    is_temperature_unsupported_error,
+    remove_temperature_param,
 )
 from src.services.notification_service import build_notification_service
 from src.utils import convert_goofish_link, retry_on_failure
@@ -327,6 +329,7 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
     # 增强的AI调用，包含更严格的结构化输出控制和重试机制
     max_retries = 3
     use_response_format = ENABLE_RESPONSE_FORMAT
+    use_temperature = True
     for attempt in range(max_retries):
         try:
             # 根据重试次数调整参数
@@ -341,6 +344,8 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
                 "temperature": current_temperature,
                 "max_output_tokens": 4000,
             }
+            if not use_temperature:
+                request_params = remove_temperature_param(request_params)
             request_params = add_json_text_format(
                 request_params,
                 use_response_format,
@@ -387,6 +392,11 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
                 use_response_format = False
                 safe_print(
                     "   [AI分析] 当前模型不支持结构化 JSON 输出，后续重试将自动禁用该参数。"
+                )
+            if use_temperature and is_temperature_unsupported_error(e):
+                use_temperature = False
+                safe_print(
+                    "   [AI分析] 当前模型不支持 temperature 参数，后续重试将自动禁用该参数。"
                 )
             safe_print(f"   [AI分析] 第{attempt + 1}次尝试AI调用失败: {e}")
             if attempt < max_retries - 1:

--- a/src/infrastructure/external/ai_client.py
+++ b/src/infrastructure/external/ai_client.py
@@ -19,6 +19,8 @@ from src.services.ai_request_compat import (
     add_json_text_format,
     build_responses_input,
     is_json_output_unsupported_error,
+    is_temperature_unsupported_error,
+    remove_temperature_param,
 )
 from src.services.ai_response_parser import extract_ai_response_content
 
@@ -124,7 +126,8 @@ class AIClient:
     async def _call_ai(self, messages: List[Dict]) -> str:
         """调用 AI API"""
         use_response_format = self.settings.enable_response_format
-        max_attempts = 2 if use_response_format else 1
+        use_temperature = True
+        max_attempts = 3
 
         for attempt in range(max_attempts):
             request_params = {
@@ -133,6 +136,8 @@ class AIClient:
                 "temperature": 0.1,
                 "max_output_tokens": 4000,
             }
+            if not use_temperature:
+                request_params = remove_temperature_param(request_params)
             request_params = add_json_text_format(
                 request_params,
                 use_response_format,
@@ -144,11 +149,17 @@ class AIClient:
             try:
                 response = await self.client.responses.create(**request_params)
             except Exception as exc:
+                changed = False
                 if use_response_format and is_json_output_unsupported_error(exc):
                     use_response_format = False
+                    changed = True
                     print("当前模型不支持结构化 JSON 输出，正在自动重试并移除该参数")
-                    if attempt < max_attempts - 1:
-                        continue
+                if use_temperature and is_temperature_unsupported_error(exc):
+                    use_temperature = False
+                    changed = True
+                    print("当前模型不支持 temperature 参数，正在自动重试并移除该参数")
+                if changed and attempt < max_attempts - 1:
+                    continue
                 raise
 
             return extract_ai_response_content(response)

--- a/src/prompt_utils.py
+++ b/src/prompt_utils.py
@@ -6,7 +6,11 @@ from typing import Awaitable, Callable, Optional
 import aiofiles
 
 from src.infrastructure.external.ai_client import AIClient
-from src.services.ai_request_compat import build_responses_input
+from src.services.ai_request_compat import (
+    build_responses_input,
+    is_temperature_unsupported_error,
+    remove_temperature_param,
+)
 from src.services.ai_response_parser import extract_ai_response_content
 
 # The meta-prompt to instruct the AI
@@ -81,23 +85,34 @@ async def generate_criteria(
     await _report_progress(progress_callback, "llm", "正在调用 AI 生成分析标准。")
     print("正在调用AI生成新的分析标准，请稍候...")
     try:
-        request_params = {
-            "model": ai_client.settings.model_name,
-            "input": build_responses_input([{"role": "user", "content": prompt}]),
-            "temperature": 0.5,
-        }
-        if ai_client.settings.enable_thinking:
-            request_params["extra_body"] = {"enable_thinking": False}
+        use_temperature = True
+        for _attempt in range(2):
+            request_params = {
+                "model": ai_client.settings.model_name,
+                "input": build_responses_input([{"role": "user", "content": prompt}]),
+                "temperature": 0.5,
+            }
+            if not use_temperature:
+                request_params = remove_temperature_param(request_params)
+            if ai_client.settings.enable_thinking:
+                request_params["extra_body"] = {"enable_thinking": False}
 
-        response = await ai_client.client.responses.create(**request_params)
-        generated_text = extract_ai_response_content(response)
-        print("AI已成功生成内容。")
-        
-        # 处理content可能为None或空字符串的情况
-        if generated_text is None or generated_text.strip() == "":
-            raise RuntimeError("AI返回的内容为空，请检查模型配置或重试。")
-        
-        return generated_text.strip()
+            try:
+                response = await ai_client.client.responses.create(**request_params)
+                generated_text = extract_ai_response_content(response)
+                print("AI已成功生成内容。")
+
+                # 处理content可能为None或空字符串的情况
+                if generated_text is None or generated_text.strip() == "":
+                    raise RuntimeError("AI返回的内容为空，请检查模型配置或重试。")
+
+                return generated_text.strip()
+            except Exception as e:
+                if use_temperature and is_temperature_unsupported_error(e):
+                    use_temperature = False
+                    print("当前模型不支持 temperature 参数，正在自动重试并移除该参数")
+                    continue
+                raise
     except Exception as e:
         print(f"调用 OpenAI API 时出错: {e}")
         raise e

--- a/src/services/ai_request_compat.py
+++ b/src/services/ai_request_compat.py
@@ -14,6 +14,10 @@ UNSUPPORTED_JSON_OUTPUT_MARKERS = (
     "text.format",
     "response_format.type",
 )
+UNSUPPORTED_TEMPERATURE_MARKERS = (
+    "temperature",
+    "sampling temperature",
+)
 
 
 def build_responses_input(messages: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -52,6 +56,24 @@ def is_json_output_unsupported_error(error: Exception) -> bool:
         "not supported" in message.lower()
         and any(marker in message for marker in UNSUPPORTED_JSON_OUTPUT_MARKERS)
     )
+
+
+def is_temperature_unsupported_error(error: Exception) -> bool:
+    """识别模型或中转站不支持 temperature 参数的错误。"""
+    message = str(error).lower()
+    return (
+        "not supported" in message
+        or "unsupported" in message
+        or "invalid" in message
+        or "参数错误" in message
+    ) and any(marker in message for marker in UNSUPPORTED_TEMPERATURE_MARKERS)
+
+
+def remove_temperature_param(request_params: Dict[str, Any]) -> Dict[str, Any]:
+    """移除 temperature 参数，适配不支持采样温度的模型网关。"""
+    next_params = dict(request_params)
+    next_params.pop("temperature", None)
+    return next_params
 
 
 def _build_input_content(content: Any) -> List[Dict[str, Any]]:

--- a/tests/unit/test_ai_client.py
+++ b/tests/unit/test_ai_client.py
@@ -97,3 +97,27 @@ def test_call_ai_retries_without_structured_output_when_model_rejects_it():
     assert request_history[0]["input"][0]["content"][0]["type"] == "input_text"
     assert request_history[0]["text"]["format"]["type"] == "json_object"
     assert "text" not in request_history[1]
+
+
+def test_call_ai_retries_without_temperature_when_gateway_rejects_it():
+    client = AIClient.__new__(AIClient)
+    client.settings = SimpleNamespace(
+        model_name="fake-model",
+        enable_response_format=False,
+        enable_thinking=False,
+    )
+    request_history = []
+
+    async def fake_create(**kwargs):
+        request_history.append(kwargs)
+        if len(request_history) == 1:
+            raise Exception("temperature is not supported by this gateway")
+        return SimpleNamespace(output_text='{"ok":true}')
+
+    client.client = _build_fake_client(fake_create)
+
+    response = asyncio.run(client._call_ai([{"role": "user", "content": "hi"}]))
+
+    assert response == '{"ok":true}'
+    assert request_history[0]["temperature"] == 0.1
+    assert "temperature" not in request_history[1]

--- a/tests/unit/test_ai_handler_analysis.py
+++ b/tests/unit/test_ai_handler_analysis.py
@@ -109,3 +109,38 @@ def test_get_ai_analysis_retries_without_structured_output_when_model_rejects_it
     assert request_history[0]["text"]["format"]["type"] == "json_object"
     assert "text" not in request_history[1]
     assert ai_handler.ENABLE_RESPONSE_FORMAT is True
+
+
+def test_get_ai_analysis_retries_without_temperature_when_gateway_rejects_it(
+    monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    request_history = []
+
+    async def fake_create(**kwargs):
+        request_history.append(kwargs)
+        if len(request_history) == 1:
+            raise Exception("temperature is unsupported for this model")
+        return SimpleNamespace(
+            output_text=(
+                '{"prompt_version":"v1","is_recommended":true,'
+                '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
+            )
+        )
+
+    monkeypatch.setattr(ai_handler, "client", _build_fake_client(fake_create))
+    monkeypatch.setattr(ai_handler, "MODEL_NAME", "fake-model")
+    monkeypatch.setattr(ai_handler, "ENABLE_RESPONSE_FORMAT", True)
+    monkeypatch.setattr(app_config, "ENABLE_RESPONSE_FORMAT", True)
+
+    result = asyncio.run(
+        ai_handler.get_ai_analysis(
+            {"商品信息": {"商品ID": "4", "商品标题": "测试商品4"}},
+            image_paths=[],
+            prompt_text="请输出 JSON",
+        )
+    )
+
+    assert result["reason"] == "ok"
+    assert request_history[0]["temperature"] == 0.1
+    assert "temperature" not in request_history[1]

--- a/tests/unit/test_ai_request_compat.py
+++ b/tests/unit/test_ai_request_compat.py
@@ -1,0 +1,18 @@
+from src.services.ai_request_compat import (
+    is_temperature_unsupported_error,
+    remove_temperature_param,
+)
+
+
+def test_is_temperature_unsupported_error_detects_unsupported_message():
+    err = Exception("temperature is not supported by this gateway")
+    assert is_temperature_unsupported_error(err) is True
+
+
+def test_remove_temperature_param_removes_only_temperature():
+    params = {"model": "x", "temperature": 0.5, "max_output_tokens": 128}
+    result = remove_temperature_param(params)
+
+    assert "temperature" not in result
+    assert result["model"] == "x"
+    assert result["max_output_tokens"] == 128


### PR DESCRIPTION
### Motivation
- Some third-party gateway/proxy endpoints return a 400 when receiving a `temperature` parameter, causing AI calls to fail; the goal is to detect that case and retry without the parameter.

### Description
- Add compatibility helpers `is_temperature_unsupported_error` and `remove_temperature_param` in `src/services/ai_request_compat.py` to detect gateway errors and strip `temperature` from request params.
- Add automatic downgrade-and-retry logic to AI callers so the first request still sends `temperature`, and on detection of an unsupported-`temperature` error subsequent retries remove it: `src/infrastructure/external/ai_client.py`, `src/ai_handler.py`, and `src/prompt_utils.py`.
- Add and extend unit tests to cover the new detection and retry behavior (`tests/unit/test_ai_request_compat.py`, updates to `tests/unit/test_ai_client.py` and `tests/unit/test_ai_handler_analysis.py`).

### Testing
- Run `pytest tests/unit/test_ai_request_compat.py tests/unit/test_ai_client.py tests/unit/test_ai_handler_analysis.py`, which executed the new and updated unit tests.
- Test result: all tests passed (11 passed) when executing the above test set.
- Existing JSON-format compatibility fallback remains unchanged and can co-occur with the new `temperature` fallback logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e323b76483339260dc0075bc7fa3)