### PR TITLE
fix(keyword): 解决纯英数字关键词部分匹配问题

### DIFF
--- a/src/keyword_rule_engine.py
+++ b/src/keyword_rule_engine.py
@@ -1,7 +1,13 @@
 """
 关键词判断引擎：单组 OR 逻辑，命中任意关键词即推荐。
+纯英数字关键词按完整词匹配，避免 Q1 误命中 Q1R5。
 """
+import re
 from typing import Any, Dict, Iterable, List
+
+
+_ASCII_TOKEN_KEYWORD_PATTERN = re.compile(r"^[a-z0-9 ]+$")
+_ASCII_TOKEN_BOUNDARY = r"[a-z0-9]"
 
 
 def normalize_text(value: str) -> str:
@@ -52,6 +58,17 @@ def _normalize_keywords(values: Iterable[str]) -> List[str]:
     return normalized
 
 
+def _uses_ascii_token_match(keyword: str) -> bool:
+    return bool(keyword) and _ASCII_TOKEN_KEYWORD_PATTERN.fullmatch(keyword) is not None
+
+
+def _keyword_matches(keyword: str, normalized_text: str) -> bool:
+    if not _uses_ascii_token_match(keyword):
+        return keyword in normalized_text
+    pattern = rf"(?<!{_ASCII_TOKEN_BOUNDARY}){re.escape(keyword)}(?!{_ASCII_TOKEN_BOUNDARY})"
+    return re.search(pattern, normalized_text) is not None
+
+
 def evaluate_keyword_rules(keywords: List[str], search_text: str) -> Dict[str, Any]:
     normalized_text = normalize_text(search_text)
     normalized_keywords = _normalize_keywords(keywords)
@@ -74,7 +91,7 @@ def evaluate_keyword_rules(keywords: List[str], search_text: str) -> Dict[str, A
             "keyword_hit_count": 0,
         }
 
-    matched_keywords = [kw for kw in normalized_keywords if kw in normalized_text]
+    matched_keywords = [kw for kw in normalized_keywords if _keyword_matches(kw, normalized_text)]
     hit_count = len(matched_keywords)
     is_recommended = hit_count > 0
 

--- a/tests/unit/test_keyword_rule_engine.py
+++ b/tests/unit/test_keyword_rule_engine.py
@@ -50,3 +50,15 @@ def test_keyword_rules_no_match():
     result = evaluate_keyword_rules(["佳能", "单反"], text)
     assert result["is_recommended"] is False
     assert result["keyword_hit_count"] == 0
+
+
+def test_keyword_rules_do_not_partially_match_alphanumeric_prefixes():
+    result = evaluate_keyword_rules(["q1"], "富士 q1r5 旗舰相机")
+    assert result["is_recommended"] is False
+    assert result["keyword_hit_count"] == 0
+
+
+def test_keyword_rules_still_match_full_alphanumeric_token():
+    result = evaluate_keyword_rules(["q1r5"], "富士 q1r5 旗舰相机")
+    assert result["is_recommended"] is True
+    assert result["keyword_hit_count"] == 1

--- a/web-ui/src/components/tasks/TaskForm.vue
+++ b/web-ui/src/components/tasks/TaskForm.vue
@@ -307,7 +307,7 @@ function handleSubmit() {
         <Label class="text-right pt-2">关键词规则</Label>
         <div class="col-span-3 space-y-2">
           <p class="text-xs text-gray-500">
-            单组 OR 逻辑：命中任一关键词即推荐（每行一个关键词，或使用逗号分隔）。
+            单组 OR 逻辑：命中任一关键词即推荐（每行一个关键词，或使用逗号分隔）。纯英数字关键词按完整词匹配。
           </p>
           <Textarea
             v-model="keywordRulesInput"


### PR DESCRIPTION
- 添加正则表达式模式检测纯英数字关键词
- 实现完整的词边界匹配避免部分匹配
- 为纯英数字关键词添加前后边界检查
- 更新测试用例验证 Q1 不匹配 Q1R5 的情况
- 添加文档说明关键词匹配规则变化
- 修复后端引擎和前端表单显示一致性