### PR TITLE
feat(deploy): 支持多容器镜像仓库部署

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,60 +1,100 @@
 name: Docker Image CI on merge to master
 
-# 双触发模式：手动触发 + PR合并自动触发
 on:
-  # 手动触发（仓库页面出现"Run workflow"按钮）
   workflow_dispatch:
-  
-  # PR合并自动触发（原逻辑保持）
   pull_request:
     types: [closed]
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   build-and-push:
-    # 双条件：手动触发或PR合并
     if: |
-      github.event_name == 'workflow_dispatch' || 
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
-    
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      # 手动触发时获取完整历史
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    # 原有Docker构建步骤保持不变...
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-    - name: Set lowercase repository owner
-      env:
-        REPO_OWNER: ${{ github.repository_owner }}
-      run: echo "REPO_OWNER_LOWER=$(echo $REPO_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare multi-registry image tags
+        id: prepare
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          IMAGE_NAME: ai-goofish
+          ACR_REGISTRY_SERVER: ${{ secrets.ACR_REGISTRY_SERVER }}
+          ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
+          ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
+          ACR_IMAGE_REPOSITORY: ${{ secrets.ACR_IMAGE_REPOSITORY }}
+        run: |
+          set -euo pipefail
 
-    - name: Build and push multi-arch Docker images
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: ./Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: |
-          ghcr.io/${{ env.REPO_OWNER_LOWER }}/ai-goofish:latest
-          ghcr.io/${{ env.REPO_OWNER_LOWER }}/ai-goofish:${{ github.sha }}
+          owner_lower=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')
+          acr_registry_server="${ACR_REGISTRY_SERVER%/}"
+          acr_image_repository="${ACR_IMAGE_REPOSITORY%/}"
+
+          enable_acr=false
+
+          tags=(
+            "ghcr.io/${owner_lower}/${IMAGE_NAME}:latest"
+            "ghcr.io/${owner_lower}/${IMAGE_NAME}:${GITHUB_SHA}"
+          )
+
+          if [ -n "$acr_registry_server" ] && [ -n "$ACR_USERNAME" ] && [ -n "$ACR_PASSWORD" ] && [ -n "$acr_image_repository" ]; then
+            case "$acr_image_repository" in
+              "${acr_registry_server}"/*) ;;
+              *)
+                echo "ACR_IMAGE_REPOSITORY 必须以 ${acr_registry_server}/ 开头" >&2
+                exit 1
+                ;;
+            esac
+
+            enable_acr=true
+            tags+=(
+              "${acr_image_repository}:latest"
+              "${acr_image_repository}:${GITHUB_SHA}"
+            )
+          fi
+
+          {
+            echo "enable_acr=${enable_acr}"
+            echo "acr_registry_server=${acr_registry_server}"
+            echo 'tags<<EOF'
+            printf '%s\n' "${tags[@]}"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Alibaba Cloud ACR
+        if: ${{ steps.prepare.outputs.enable_acr == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ steps.prepare.outputs.acr_registry_server }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Build and push multi-arch Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.prepare.outputs.tags }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/usagi-org/ai-goofish:latest
+    image: ${APP_IMAGE:-ghcr.io/usagi-org/ai-goofish:latest}
     container_name: ai-goofish-monitor-app
     pull_policy: always
     init: true


### PR DESCRIPTION
- 在docker-compose中添加环境变量支持，默认使用GitHub Container Registry
- 配置GitHub Actions工作流支持多注册表镜像推送
- 添加阿里云ACR作为可选镜像仓库配置选项
- 实现多架构镜像构建（amd64/arm64）
- 集成ACR认证和推送流程到CI/CD管道
- 支持通过环境变量控制是否启用ACR部署功能