### PR TITLE
feat(ai): 切换默认AI API模式为Chat Completions并增强错误回退机制

### DIFF
--- a/src/ai_handler.py
+++ b/src/ai_handler.py
@@ -40,6 +40,7 @@ from src.services.ai_request_compat import (
     RESPONSES_API_MODE,
     build_ai_request_params,
     create_ai_response_async,
+    is_chat_completions_api_unsupported_error,
     is_json_output_unsupported_error,
     is_responses_api_unsupported_error,
     is_temperature_unsupported_error,
@@ -369,7 +370,7 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
 
     # 增强的AI调用，包含更严格的结构化输出控制和重试机制
     max_retries = 4
-    api_mode = RESPONSES_API_MODE
+    api_mode = CHAT_COMPLETIONS_API_MODE
     use_response_format = ENABLE_RESPONSE_FORMAT
     use_temperature = True
     for attempt in range(max_retries):
@@ -442,7 +443,15 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
                 raise e
 
         except Exception as e:
-            if api_mode == RESPONSES_API_MODE and is_responses_api_unsupported_error(e):
+            if (
+                api_mode == CHAT_COMPLETIONS_API_MODE
+                and is_chat_completions_api_unsupported_error(e)
+            ):
+                api_mode = RESPONSES_API_MODE
+                safe_print(
+                    "   [AI分析] 当前服务未实现 Chat Completions API，后续重试将自动回退到 Responses API。"
+                )
+            elif api_mode == RESPONSES_API_MODE and is_responses_api_unsupported_error(e):
                 api_mode = CHAT_COMPLETIONS_API_MODE
                 safe_print(
                     "   [AI分析] 当前服务未实现 Responses API，后续重试将自动回退到 Chat Completions API。"

--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -20,6 +20,7 @@ from src.services.ai_request_compat import (
     RESPONSES_API_MODE,
     build_ai_request_params,
     create_ai_response_sync,
+    is_chat_completions_api_unsupported_error,
     is_responses_api_unsupported_error,
 )
 from src.services.ai_response_parser import extract_ai_response_content
@@ -299,7 +300,7 @@ async def test_ai_settings(settings: dict):
         model_name = settings.get("OPENAI_MODEL_NAME", "")
         client = OpenAI(**client_params)
         messages = [{"role": "user", "content": AI_TEST_PROMPT}]
-        api_mode = RESPONSES_API_MODE
+        api_mode = CHAT_COMPLETIONS_API_MODE
 
         try:
             response = create_ai_response_sync(
@@ -313,9 +314,9 @@ async def test_ai_settings(settings: dict):
                 ),
             )
         except Exception as exc:
-            if not is_responses_api_unsupported_error(exc):
+            if not is_chat_completions_api_unsupported_error(exc):
                 raise
-            api_mode = CHAT_COMPLETIONS_API_MODE
+            api_mode = RESPONSES_API_MODE
             response = create_ai_response_sync(
                 client,
                 api_mode,

--- a/src/infrastructure/external/ai_client.py
+++ b/src/infrastructure/external/ai_client.py
@@ -20,6 +20,7 @@ from src.services.ai_request_compat import (
     RESPONSES_API_MODE,
     build_ai_request_params,
     create_ai_response_async,
+    is_chat_completions_api_unsupported_error,
     is_json_output_unsupported_error,
     is_responses_api_unsupported_error,
     is_temperature_unsupported_error,
@@ -136,7 +137,7 @@ class AIClient:
         enable_json_output: Optional[bool] = None,
     ) -> str:
         """调用 AI API"""
-        api_mode = RESPONSES_API_MODE
+        api_mode = CHAT_COMPLETIONS_API_MODE
         use_response_format = (
             self.settings.enable_response_format
             if enable_json_output is None
@@ -168,7 +169,17 @@ class AIClient:
                 )
             except Exception as exc:
                 changed = False
-                if api_mode == RESPONSES_API_MODE and is_responses_api_unsupported_error(exc):
+                if (
+                    api_mode == CHAT_COMPLETIONS_API_MODE
+                    and is_chat_completions_api_unsupported_error(exc)
+                ):
+                    api_mode = RESPONSES_API_MODE
+                    changed = True
+                    print("当前服务未实现 Chat Completions API，正在自动回退到 Responses API")
+                elif (
+                    api_mode == RESPONSES_API_MODE
+                    and is_responses_api_unsupported_error(exc)
+                ):
                     api_mode = CHAT_COMPLETIONS_API_MODE
                     changed = True
                     print("当前服务未实现 Responses API，正在自动回退到 Chat Completions API")

--- a/src/services/ai_request_compat.py
+++ b/src/services/ai_request_compat.py
@@ -23,6 +23,12 @@ RESPONSES_API_UNSUPPORTED_MARKERS = (
     "/responses",
     "/v1/responses",
 )
+CHAT_COMPLETIONS_API_UNSUPPORTED_MARKERS = (
+    "404 page not found",
+    "page not found",
+    "/chat/completions",
+    "/v1/chat/completions",
+)
 UNSUPPORTED_TEMPERATURE_MARKERS = (
     "temperature",
     "sampling temperature",
@@ -80,20 +86,12 @@ def is_json_output_unsupported_error(error: Exception) -> bool:
 
 def is_responses_api_unsupported_error(error: Exception) -> bool:
     """识别 OpenAI 兼容服务未实现 Responses API 的错误。"""
-    message = str(error).lower()
-    if any(marker in message for marker in RESPONSES_API_UNSUPPORTED_MARKERS):
-        return True
+    return _is_api_unsupported_error(error, RESPONSES_API_UNSUPPORTED_MARKERS)
 
-    status_code = getattr(error, "status_code", None)
-    body = getattr(error, "body", None)
-    response = getattr(error, "response", None)
-    response_text = getattr(response, "text", None) if response else None
-    return (
-        status_code == 404
-        and message.strip() == "error code: 404"
-        and not body
-        and not response_text
-    )
+
+def is_chat_completions_api_unsupported_error(error: Exception) -> bool:
+    """识别 OpenAI 兼容服务未实现 Chat Completions API 的错误。"""
+    return _is_api_unsupported_error(error, CHAT_COMPLETIONS_API_UNSUPPORTED_MARKERS)
 
 
 def build_ai_request_params(
@@ -168,6 +166,26 @@ def remove_temperature_param(request_params: Dict[str, Any]) -> Dict[str, Any]:
     next_params = dict(request_params)
     next_params.pop("temperature", None)
     return next_params
+
+
+def _is_api_unsupported_error(
+    error: Exception,
+    markers: tuple[str, ...],
+) -> bool:
+    message = str(error).lower()
+    if any(marker in message for marker in markers):
+        return True
+
+    status_code = getattr(error, "status_code", None)
+    body = getattr(error, "body", None)
+    response = getattr(error, "response", None)
+    response_text = getattr(response, "text", None) if response else None
+    return (
+        status_code == 404
+        and message.strip() == "error code: 404"
+        and not body
+        and not response_text
+    )
 
 
 def _build_input_content(content: Any) -> List[Dict[str, Any]]:

--- a/tests/integration/test_api_settings.py
+++ b/tests/integration/test_api_settings.py
@@ -328,7 +328,7 @@ def test_notification_settings_fall_back_to_runtime_environment_when_env_file_mi
     assert sorted(payload["CONFIGURED_CHANNELS"]) == ["bark", "ntfy", "telegram"]
 
 
-def test_ai_test_endpoint_falls_back_to_chat_completions_when_responses_api_404(
+def test_ai_test_endpoint_falls_back_to_responses_when_chat_completions_api_404(
     tmp_path, monkeypatch
 ):
     _clear_settings_env(monkeypatch)
@@ -359,29 +359,15 @@ def test_ai_test_endpoint_falls_back_to_chat_completions_when_responses_api_404(
 
         def _responses_create(self, **kwargs):
             request_history.append(("responses", kwargs))
-            raise Exception("Error code: 404 - page not found")
-
-        def _chat_create(self, **kwargs):
-            request_history.append(("chat", kwargs))
             return type(
                 "_Response",
                 (),
-                {
-                    "choices": [
-                        type(
-                            "_Choice",
-                            (),
-                            {
-                                "message": type(
-                                    "_Message",
-                                    (),
-                                    {"content": "OK"},
-                                )()
-                            },
-                        )()
-                    ]
-                },
+                {"output_text": "OK"},
             )()
+
+        def _chat_create(self, **kwargs):
+            request_history.append(("chat", kwargs))
+            raise Exception("Error code: 404 - page not found")
 
     import openai
 
@@ -400,6 +386,7 @@ def test_ai_test_endpoint_falls_back_to_chat_completions_when_responses_api_404(
     payload = response.json()
     assert payload["success"] is True
     assert payload["response"] == "OK"
-    assert request_history[0][0] == "responses"
-    assert request_history[1][0] == "chat"
-    assert request_history[1][1]["messages"][0]["content"] == settings.AI_TEST_PROMPT
+    assert request_history[0][0] == "chat"
+    assert request_history[0][1]["messages"][0]["content"] == settings.AI_TEST_PROMPT
+    assert request_history[1][0] == "responses"
+    assert request_history[1][1]["input"][0]["content"][0]["text"] == settings.AI_TEST_PROMPT

--- a/tests/unit/test_ai_client.py
+++ b/tests/unit/test_ai_client.py
@@ -86,40 +86,6 @@ def test_call_ai_retries_without_structured_output_when_model_rejects_it():
         if len(request_history) == 1:
             raise Exception(
                 "Error code: 400 - {'error': {'code': 'InvalidParameter', "
-                "'message': 'The parameter `text.format.type` specified in "
-                "the request are not valid: `json_object` is not supported by "
-                "this model.', 'param': 'text.format.type'}}"
-            )
-        return SimpleNamespace(output_text='{"ok":true}')
-
-    client.client = _build_fake_client(fake_create)
-
-    response = asyncio.run(client._call_ai([{"role": "user", "content": "hi"}]))
-
-    assert response == '{"ok":true}'
-    assert request_history[0]["input"][0]["content"][0]["type"] == "input_text"
-    assert request_history[0]["text"]["format"]["type"] == "json_object"
-    assert "text" not in request_history[1]
-
-
-def test_call_ai_falls_back_to_chat_completions_when_responses_api_is_missing():
-    client = AIClient.__new__(AIClient)
-    client.settings = SimpleNamespace(
-        model_name="fake-model",
-        enable_response_format=True,
-        enable_thinking=False,
-    )
-    request_history = []
-
-    async def fake_responses_create(**kwargs):
-        request_history.append(("responses", kwargs))
-        raise Exception("Error code: 404 - page not found")
-
-    async def fake_chat_create(**kwargs):
-        request_history.append(("chat", kwargs))
-        if len([item for item in request_history if item[0] == "chat"]) == 1:
-            raise Exception(
-                "Error code: 400 - {'error': {'code': 'InvalidParameter', "
                 "'message': 'The parameter `response_format.type` specified in "
                 "the request are not valid: `json_object` is not supported by "
                 "this model.', 'param': 'response_format.type'}}"
@@ -132,16 +98,50 @@ def test_call_ai_falls_back_to_chat_completions_when_responses_api_is_missing():
             ]
         )
 
+    client.client = _build_fake_client(fake_create)
+
+    response = asyncio.run(client._call_ai([{"role": "user", "content": "hi"}]))
+
+    assert response == '{"ok":true}'
+    assert request_history[0]["messages"][0]["content"] == "hi"
+    assert request_history[0]["response_format"]["type"] == "json_object"
+    assert "response_format" not in request_history[1]
+
+
+def test_call_ai_falls_back_to_responses_when_chat_completions_api_is_missing():
+    client = AIClient.__new__(AIClient)
+    client.settings = SimpleNamespace(
+        model_name="fake-model",
+        enable_response_format=True,
+        enable_thinking=False,
+    )
+    request_history = []
+
+    async def fake_chat_create(**kwargs):
+        request_history.append(("chat", kwargs))
+        raise Exception("Error code: 404 - page not found")
+
+    async def fake_responses_create(**kwargs):
+        request_history.append(("responses", kwargs))
+        if len([item for item in request_history if item[0] == "responses"]) == 1:
+            raise Exception(
+                "Error code: 400 - {'error': {'code': 'InvalidParameter', "
+                "'message': 'The parameter `text.format.type` specified in "
+                "the request are not valid: `json_object` is not supported by "
+                "this model.', 'param': 'text.format.type'}}"
+            )
+        return SimpleNamespace(output_text='{"ok":true}')
+
     client.client = _build_fake_client(fake_responses_create, fake_chat_create)
 
     response = asyncio.run(client._call_ai([{"role": "user", "content": "hi"}]))
 
     assert response == '{"ok":true}'
-    assert request_history[0][0] == "responses"
-    assert request_history[1][0] == "chat"
-    assert request_history[1][1]["response_format"]["type"] == "json_object"
-    assert request_history[2][0] == "chat"
-    assert "response_format" not in request_history[2][1]
+    assert request_history[0][0] == "chat"
+    assert request_history[1][0] == "responses"
+    assert request_history[1][1]["text"]["format"]["type"] == "json_object"
+    assert request_history[2][0] == "responses"
+    assert "text" not in request_history[2][1]
 
 
 def test_call_ai_retries_without_temperature_when_gateway_rejects_it():
@@ -157,7 +157,13 @@ def test_call_ai_retries_without_temperature_when_gateway_rejects_it():
         request_history.append(kwargs)
         if len(request_history) == 1:
             raise Exception("temperature is not supported by this gateway")
-        return SimpleNamespace(output_text='{"ok":true}')
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content='{"ok":true}')
+                )
+            ]
+        )
 
     client.client = _build_fake_client(fake_create)
 

--- a/tests/unit/test_ai_handler_analysis.py
+++ b/tests/unit/test_ai_handler_analysis.py
@@ -83,15 +83,21 @@ def test_get_ai_analysis_retries_without_structured_output_when_model_rejects_it
         if len(request_history) == 1:
             raise Exception(
                 "Error code: 400 - {'error': {'code': 'InvalidParameter', "
-                "'message': 'The parameter `text.format.type` specified in "
+                "'message': 'The parameter `response_format.type` specified in "
                 "the request are not valid: `json_object` is not supported by "
-                "this model.', 'param': 'text.format.type'}}"
+                "this model.', 'param': 'response_format.type'}}"
             )
         return SimpleNamespace(
-            output_text=(
-                '{"prompt_version":"v1","is_recommended":true,'
-                '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
-            )
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=(
+                            '{"prompt_version":"v1","is_recommended":true,'
+                            '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
+                        )
+                    )
+                )
+            ]
         )
 
     monkeypatch.setattr(ai_handler, "client", _build_fake_client(fake_create))
@@ -108,42 +114,36 @@ def test_get_ai_analysis_retries_without_structured_output_when_model_rejects_it
     )
 
     assert result["reason"] == "ok"
-    assert request_history[0]["input"][0]["content"][0]["type"] == "input_text"
-    assert request_history[0]["text"]["format"]["type"] == "json_object"
-    assert "text" not in request_history[1]
+    assert request_history[0]["messages"][0]["role"] == "user"
+    assert request_history[0]["response_format"]["type"] == "json_object"
+    assert "response_format" not in request_history[1]
     assert ai_handler.ENABLE_RESPONSE_FORMAT is True
 
 
-def test_get_ai_analysis_falls_back_to_chat_completions_when_responses_api_is_missing(
+def test_get_ai_analysis_falls_back_to_responses_when_chat_completions_api_is_missing(
     monkeypatch, tmp_path
 ):
     monkeypatch.chdir(tmp_path)
     request_history = []
 
-    async def fake_responses_create(**kwargs):
-        request_history.append(("responses", kwargs))
-        raise Exception("Error code: 404 - page not found")
-
     async def fake_chat_create(**kwargs):
         request_history.append(("chat", kwargs))
-        if len([item for item in request_history if item[0] == "chat"]) == 1:
+        raise Exception("Error code: 404 - page not found")
+
+    async def fake_responses_create(**kwargs):
+        request_history.append(("responses", kwargs))
+        if len([item for item in request_history if item[0] == "responses"]) == 1:
             raise Exception(
                 "Error code: 400 - {'error': {'code': 'InvalidParameter', "
-                "'message': 'The parameter `response_format.type` specified in "
+                "'message': 'The parameter `text.format.type` specified in "
                 "the request are not valid: `json_object` is not supported by "
-                "this model.', 'param': 'response_format.type'}}"
+                "this model.', 'param': 'text.format.type'}}"
             )
         return SimpleNamespace(
-            choices=[
-                SimpleNamespace(
-                    message=SimpleNamespace(
-                        content=(
-                            '{"prompt_version":"v1","is_recommended":true,'
-                            '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
-                        )
-                    )
-                )
-            ]
+            output_text=(
+                '{"prompt_version":"v1","is_recommended":true,'
+                '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
+            )
         )
 
     monkeypatch.setattr(
@@ -164,12 +164,12 @@ def test_get_ai_analysis_falls_back_to_chat_completions_when_responses_api_is_mi
     )
 
     assert result["reason"] == "ok"
-    assert request_history[0][0] == "responses"
-    assert request_history[0][1]["input"][0]["content"][0]["type"] == "input_text"
-    assert request_history[1][0] == "chat"
-    assert request_history[1][1]["response_format"]["type"] == "json_object"
-    assert request_history[2][0] == "chat"
-    assert "response_format" not in request_history[2][1]
+    assert request_history[0][0] == "chat"
+    assert request_history[0][1]["messages"][0]["role"] == "user"
+    assert request_history[1][0] == "responses"
+    assert request_history[1][1]["text"]["format"]["type"] == "json_object"
+    assert request_history[2][0] == "responses"
+    assert "text" not in request_history[2][1]
 
 
 def test_get_ai_analysis_retries_without_temperature_when_gateway_rejects_it(
@@ -183,10 +183,16 @@ def test_get_ai_analysis_retries_without_temperature_when_gateway_rejects_it(
         if len(request_history) == 1:
             raise Exception("temperature is unsupported for this model")
         return SimpleNamespace(
-            output_text=(
-                '{"prompt_version":"v1","is_recommended":true,'
-                '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
-            )
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=(
+                            '{"prompt_version":"v1","is_recommended":true,'
+                            '"reason":"ok","risk_tags":[],"criteria_analysis":{"seller_type":"个人"}}'
+                        )
+                    )
+                )
+            ]
         )
 
     monkeypatch.setattr(ai_handler, "client", _build_fake_client(fake_create))


### PR DESCRIPTION
- 将默认AI API模式从Responses API切换到Chat Completions API
- 添加Chat Completions API不支持错误的检测和处理逻辑
- 实现API模式自动回退功能，当一个API不可用时自动切换到另一个
- 更新错误检测函数，统一API不支持错误的判断逻辑
- 修改测试用例以适配新的API调用模式和回退机制
- 在设置端点中更新AI测试的API模式切换逻辑