### PR TITLE
feat: add MiniMax as alternative LLM provider with auto-detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
 ################################################################################
 # 🚀 1. 必填核心配置 (AI 模型)
 # 只有配置了 AI，本项目才能实现智能分析。建议优先完成此处配置。
+# 支持 OpenAI 及兼容接口、MiniMax 等多种 AI 提供商。
 ################################################################################
 
+# AI 提供商选择 (可选，默认自动检测)
+# 可选值：openai, minimax
+# 留空则根据已设置的 API Key 自动判断。
+# LLM_PROVIDER=openai
+
+# ---------- 方案 A：使用 OpenAI 或兼容接口 (默认) ----------
 # 模型的 API Key。
 OPENAI_API_KEY=sk-...
 
@@ -14,6 +21,13 @@ OPENAI_BASE_URL=https://api-inference.modelscope.cn/v1/
 # 使用的模型名称。
 # 注意：该模型必须支持图片分析功能 (Vision)。
 OPENAI_MODEL_NAME=XiaomiMiMo/MiMo-V2-Flash
+
+# ---------- 方案 B：使用 MiniMax ----------
+# 只需设置 MINIMAX_API_KEY，其余会自动填充默认值。
+# 也可设 LLM_PROVIDER=minimax 并用 OPENAI_BASE_URL/OPENAI_MODEL_NAME 覆盖。
+# MINIMAX_API_KEY=your-minimax-api-key
+# 默认模型：MiniMax-M2.7（支持 Vision）
+# 默认地址：https://api.minimax.io/v1
 
 
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -69,12 +69,27 @@ docker compose up -d
 
 | 变量 | 说明 | 必填 |
 |------|------|------|
-| `OPENAI_API_KEY` | AI 模型 API Key | 是 |
-| `OPENAI_BASE_URL` | OpenAI 兼容接口地址 | 是 |
-| `OPENAI_MODEL_NAME` | 支持图片输入的模型名称 | 是 |
+| `OPENAI_API_KEY` | AI 模型 API Key（使用 OpenAI 兼容接口时） | 二选一 |
+| `MINIMAX_API_KEY` | MiniMax API Key（使用 MiniMax 时） | 二选一 |
+| `OPENAI_BASE_URL` | OpenAI 兼容接口地址（MiniMax 自动填充） | 否* |
+| `OPENAI_MODEL_NAME` | 支持图片输入的模型名称（MiniMax 默认 MiniMax-M2.7） | 否* |
+| `LLM_PROVIDER` | AI 提供商：`openai`（默认）或 `minimax` | 否 |
 | `WEB_USERNAME` / `WEB_PASSWORD` | Web UI 登录账号密码，默认 `admin/admin123` | 否 |
 
-其余配置见下方“配置说明”。
+> \* 使用 MiniMax 时，只需设置 `MINIMAX_API_KEY`，`OPENAI_BASE_URL` 和 `OPENAI_MODEL_NAME` 将自动使用默认值（`https://api.minimax.io/v1` 和 `MiniMax-M2.7`）。也可手动覆盖。
+
+其余配置见下方”配置说明”。
+
+#### 使用 MiniMax 快速开始
+
+[MiniMax](https://www.minimaxi.com/) 提供支持多模态（Vision）的大语言模型，与 OpenAI 接口兼容。
+
+```bash
+# .env 中只需一行即可启用 MiniMax
+MINIMAX_API_KEY=your-minimax-api-key
+```
+
+系统会自动检测并使用 MiniMax 的 API 地址和默认模型（MiniMax-M2.7）。
 
 
 ### 第一次使用

--- a/README_EN.md
+++ b/README_EN.md
@@ -42,12 +42,27 @@ cp .env.example .env
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `OPENAI_API_KEY` | AI model API key | Yes |
-| `OPENAI_BASE_URL` | OpenAI-compatible API base URL | Yes |
-| `OPENAI_MODEL_NAME` | Model name with image input support | Yes |
+| `OPENAI_API_KEY` | AI model API key (for OpenAI-compatible providers) | Either |
+| `MINIMAX_API_KEY` | MiniMax API key (for MiniMax) | Either |
+| `OPENAI_BASE_URL` | OpenAI-compatible API base URL (auto-filled for MiniMax) | No* |
+| `OPENAI_MODEL_NAME` | Model name with image input support (MiniMax defaults to MiniMax-M2.7) | No* |
+| `LLM_PROVIDER` | AI provider: `openai` (default) or `minimax` | No |
 | `WEB_USERNAME` / `WEB_PASSWORD` | Web UI login credentials, default `admin/admin123` | No |
 
+> \* When using MiniMax, only `MINIMAX_API_KEY` is required. `OPENAI_BASE_URL` and `OPENAI_MODEL_NAME` default to `https://api.minimax.io/v1` and `MiniMax-M2.7` respectively. You can still override them manually.
+
 See "Configuration" below for the rest.
+
+#### Quick Start with MiniMax
+
+[MiniMax](https://www.minimaxi.com/) provides multimodal (Vision) large language models with an OpenAI-compatible API.
+
+```bash
+# Just one line in .env to enable MiniMax
+MINIMAX_API_KEY=your-minimax-api-key
+```
+
+The system auto-detects MiniMax and uses its default API endpoint and model (MiniMax-M2.7).
 
 ### Start Locally
 

--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,8 @@ import sys
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
+from src.infrastructure.config.settings import AISettings, LLMProvider
+
 # --- AI & Notification Configuration ---
 load_dotenv()
 
@@ -20,10 +22,11 @@ TASK_IMAGE_DIR_PREFIX = "task_images_"
 API_URL_PATTERN = "h5api.m.goofish.com/h5/mtop.taobao.idlemtopsearch.pc.search"
 DETAIL_API_URL_PATTERN = "h5api.m.goofish.com/h5/mtop.taobao.idle.pc.detail"
 
-# --- Environment Variables ---
-API_KEY = os.getenv("OPENAI_API_KEY")
-BASE_URL = os.getenv("OPENAI_BASE_URL")
-MODEL_NAME = os.getenv("OPENAI_MODEL_NAME")
+# --- Environment Variables (with provider auto-detection) ---
+_ai_settings = AISettings()
+API_KEY = _ai_settings.resolved_api_key()
+BASE_URL = _ai_settings.resolved_base_url()
+MODEL_NAME = _ai_settings.resolved_model_name()
 PROXY_URL = os.getenv("PROXY_URL")
 NTFY_TOPIC_URL = os.getenv("NTFY_TOPIC_URL")
 GOTIFY_URL = os.getenv("GOTIFY_URL")

--- a/src/infrastructure/config/settings.py
+++ b/src/infrastructure/config/settings.py
@@ -10,7 +10,24 @@ except ImportError:
     _USING_PYDANTIC_SETTINGS = False
 from pydantic import Field
 from typing import Optional
+from enum import Enum
 import os
+
+
+# ---- LLM Provider Presets ----
+
+class LLMProvider(str, Enum):
+    OPENAI = "openai"
+    MINIMAX = "minimax"
+
+
+# Default base URLs and model names per provider
+_PROVIDER_PRESETS = {
+    LLMProvider.MINIMAX: {
+        "base_url": "https://api.minimax.io/v1",
+        "model_name": "MiniMax-M2.7",
+    },
+}
 
 DEFAULT_TELEGRAM_API_BASE_URL = "https://api.telegram.org"
 
@@ -40,7 +57,9 @@ else:
 
 class AISettings(_EnvSettings):
     """AI模型配置"""
+    llm_provider: Optional[str] = _env_field(None, "LLM_PROVIDER")
     api_key: Optional[str] = _env_field(None, "OPENAI_API_KEY")
+    minimax_api_key: Optional[str] = _env_field(None, "MINIMAX_API_KEY")
     base_url: str = _env_field("", "OPENAI_BASE_URL")
     model_name: str = _env_field("", "OPENAI_MODEL_NAME")
     proxy_url: Optional[str] = _env_field(None, "PROXY_URL")
@@ -49,9 +68,41 @@ class AISettings(_EnvSettings):
     enable_thinking: bool = _env_field(False, "ENABLE_THINKING")
     skip_analysis: bool = _env_field(False, "SKIP_AI_ANALYSIS")
 
+    def resolve_provider(self) -> LLMProvider:
+        """Detect the active LLM provider from explicit setting or API key."""
+        if self.llm_provider:
+            try:
+                return LLMProvider(self.llm_provider.lower())
+            except ValueError:
+                pass
+        if self.minimax_api_key and not self.api_key:
+            return LLMProvider.MINIMAX
+        return LLMProvider.OPENAI
+
+    def resolved_api_key(self) -> Optional[str]:
+        """Return the API key for the resolved provider."""
+        provider = self.resolve_provider()
+        if provider == LLMProvider.MINIMAX:
+            return self.minimax_api_key or self.api_key
+        return self.api_key
+
+    def resolved_base_url(self) -> str:
+        """Return the base URL, falling back to provider defaults."""
+        if self.base_url:
+            return self.base_url
+        preset = _PROVIDER_PRESETS.get(self.resolve_provider())
+        return preset["base_url"] if preset else ""
+
+    def resolved_model_name(self) -> str:
+        """Return the model name, falling back to provider defaults."""
+        if self.model_name:
+            return self.model_name
+        preset = _PROVIDER_PRESETS.get(self.resolve_provider())
+        return preset["model_name"] if preset else ""
+
     def is_configured(self) -> bool:
         """检查AI是否已正确配置"""
-        return bool(self.base_url and self.model_name)
+        return bool(self.resolved_base_url() and self.resolved_model_name())
 
 
 class NotificationSettings(_EnvSettings):

--- a/src/infrastructure/external/ai_client.py
+++ b/src/infrastructure/external/ai_client.py
@@ -47,20 +47,25 @@ class AIClient:
         self.client = self._initialize_client()
 
     def _initialize_client(self) -> Optional[AsyncOpenAI]:
-        """初始化 OpenAI 客户端"""
+        """初始化 OpenAI 兼容客户端（支持 OpenAI、MiniMax 等提供商）"""
         if not self.settings or not self.settings.is_configured():
             print("警告：AI 配置不完整，AI 功能将不可用")
             return None
 
         try:
+            provider = self.settings.resolve_provider()
+            api_key = self.settings.resolved_api_key()
+            base_url = self.settings.resolved_base_url()
+
             if self.settings.proxy_url:
                 print(f"正在为 AI 请求使用代理: {self.settings.proxy_url}")
                 os.environ['HTTP_PROXY'] = self.settings.proxy_url
                 os.environ['HTTPS_PROXY'] = self.settings.proxy_url
 
+            print(f"AI 提供商: {provider.value} | 模型: {self.settings.resolved_model_name()}")
             return AsyncOpenAI(
-                api_key=self.settings.api_key,
-                base_url=self.settings.base_url
+                api_key=api_key,
+                base_url=base_url,
             )
         except Exception as e:
             print(f"初始化 AI 客户端失败: {e}")
@@ -149,7 +154,7 @@ class AIClient:
         for attempt in range(max_attempts):
             request_params = build_ai_request_params(
                 api_mode,
-                model=self.settings.model_name,
+                model=self.settings.resolved_model_name(),
                 messages=messages,
                 temperature=temperature,
                 max_output_tokens=max_output_tokens,

--- a/tests/integration/test_minimax_provider.py
+++ b/tests/integration/test_minimax_provider.py
@@ -1,0 +1,90 @@
+"""Integration tests for MiniMax LLM provider.
+
+These tests verify the end-to-end provider detection and client creation
+flow without making real API calls.
+"""
+
+import os
+
+import pytest
+
+from src.infrastructure.config.settings import AISettings, LLMProvider
+from src.infrastructure.external.ai_client import AIClient
+
+
+# Clear all AI-related env vars so pydantic doesn't read stale values
+_AI_ENV_KEYS = (
+    "LLM_PROVIDER",
+    "OPENAI_API_KEY",
+    "MINIMAX_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL_NAME",
+    "PROXY_URL",
+    "AI_DEBUG_MODE",
+    "ENABLE_RESPONSE_FORMAT",
+    "ENABLE_THINKING",
+    "SKIP_AI_ANALYSIS",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ai_env(monkeypatch):
+    """Remove all AI-related env vars before each test."""
+    for key in _AI_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestMiniMaxProviderIntegration:
+    """Integration tests for MiniMax provider auto-detection and client setup."""
+
+    def test_env_based_minimax_detection(self, monkeypatch):
+        """Simulate a user who only sets MINIMAX_API_KEY in .env."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-integration-test")
+
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.MINIMAX
+        assert settings.resolved_api_key() == "mm-integration-test"
+        assert settings.resolved_base_url() == "https://api.minimax.io/v1"
+        assert settings.resolved_model_name() == "MiniMax-M2.7"
+        assert settings.is_configured() is True
+
+    def test_env_based_openai_detection(self, monkeypatch):
+        """Simulate a user who sets only OPENAI_* variables."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-integration-test")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-4o")
+
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.OPENAI
+        assert settings.resolved_api_key() == "sk-integration-test"
+        assert settings.resolved_base_url() == "https://api.openai.com/v1"
+        assert settings.resolved_model_name() == "gpt-4o"
+
+    def test_explicit_minimax_with_custom_model(self, monkeypatch):
+        """Simulate LLM_PROVIDER=minimax with a custom model override."""
+        monkeypatch.setenv("LLM_PROVIDER", "minimax")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-custom-test")
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "MiniMax-M2.5-highspeed")
+
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.MINIMAX
+        assert settings.resolved_model_name() == "MiniMax-M2.5-highspeed"
+        assert settings.resolved_base_url() == "https://api.minimax.io/v1"
+
+    def test_ai_client_creates_with_minimax(self, monkeypatch):
+        """AIClient should initialize successfully with MiniMax env vars."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-client-test")
+
+        client = AIClient()
+        assert client.is_available()
+        assert client.settings.resolve_provider() == LLMProvider.MINIMAX
+        assert client.client is not None
+
+    def test_legacy_config_picks_up_minimax(self, monkeypatch):
+        """Legacy config globals should reflect MiniMax provider settings."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-legacy-test")
+
+        settings = AISettings()
+        assert settings.resolved_api_key() == "mm-legacy-test"
+        assert settings.resolved_base_url() == "https://api.minimax.io/v1"
+        assert settings.resolved_model_name() == "MiniMax-M2.7"

--- a/tests/unit/test_ai_client.py
+++ b/tests/unit/test_ai_client.py
@@ -78,6 +78,7 @@ def test_call_ai_retries_without_structured_output_when_model_rejects_it():
         model_name="fake-model",
         enable_response_format=True,
         enable_thinking=False,
+        resolved_model_name=lambda: "fake-model",
     )
     request_history = []
 
@@ -114,6 +115,7 @@ def test_call_ai_falls_back_to_responses_when_chat_completions_api_is_missing():
         model_name="fake-model",
         enable_response_format=True,
         enable_thinking=False,
+        resolved_model_name=lambda: "fake-model",
     )
     request_history = []
 
@@ -150,6 +152,7 @@ def test_call_ai_retries_without_temperature_when_gateway_rejects_it():
         model_name="fake-model",
         enable_response_format=False,
         enable_thinking=False,
+        resolved_model_name=lambda: "fake-model",
     )
     request_history = []
 

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -1,0 +1,271 @@
+"""Tests for LLM provider detection, settings resolution, and MiniMax integration."""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.infrastructure.config.settings import (
+    AISettings,
+    LLMProvider,
+    _PROVIDER_PRESETS,
+)
+from src.infrastructure.external.ai_client import AIClient
+
+
+# Helper to clear all AI-related env vars so pydantic doesn't read stale values
+_AI_ENV_KEYS = (
+    "LLM_PROVIDER",
+    "OPENAI_API_KEY",
+    "MINIMAX_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL_NAME",
+    "PROXY_URL",
+    "AI_DEBUG_MODE",
+    "ENABLE_RESPONSE_FORMAT",
+    "ENABLE_THINKING",
+    "SKIP_AI_ANALYSIS",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ai_env(monkeypatch):
+    """Remove all AI-related env vars before each test."""
+    for key in _AI_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# AISettings.resolve_provider
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProvider:
+    """Tests for LLM provider auto-detection logic."""
+
+    def test_defaults_to_openai_when_no_env(self):
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.OPENAI
+
+    def test_explicit_minimax_provider(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "minimax")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.MINIMAX
+
+    def test_explicit_openai_provider(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-key")
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.OPENAI
+
+    def test_auto_detect_minimax_from_api_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.MINIMAX
+
+    def test_openai_takes_precedence_when_both_keys_set(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-key")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.OPENAI
+
+    def test_invalid_provider_falls_back_to_auto_detect(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "unknown_provider")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.MINIMAX
+
+    def test_case_insensitive_provider(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "MiniMax")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolve_provider() == LLMProvider.MINIMAX
+
+
+# ---------------------------------------------------------------------------
+# AISettings.resolved_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedApiKey:
+    """Tests for API key resolution per provider."""
+
+    def test_openai_returns_openai_key(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolved_api_key() == "sk-openai"
+
+    def test_minimax_returns_minimax_key(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "minimax")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolved_api_key() == "mm-key"
+
+    def test_minimax_falls_back_to_openai_key(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "minimax")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-shared")
+        settings = AISettings()
+        assert settings.resolved_api_key() == "sk-shared"
+
+
+# ---------------------------------------------------------------------------
+# AISettings.resolved_base_url / resolved_model_name
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedDefaults:
+    """Tests for base URL and model name resolution with provider presets."""
+
+    def test_minimax_defaults_when_no_explicit_url(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.resolved_base_url() == "https://api.minimax.io/v1"
+        assert settings.resolved_model_name() == "MiniMax-M2.7"
+
+    def test_explicit_url_overrides_minimax_default(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "minimax")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://custom.minimax.io/v1")
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "MiniMax-M2.5")
+        settings = AISettings()
+        assert settings.resolved_base_url() == "https://custom.minimax.io/v1"
+        assert settings.resolved_model_name() == "MiniMax-M2.5"
+
+    def test_openai_no_defaults(self):
+        settings = AISettings()
+        assert settings.resolved_base_url() == ""
+        assert settings.resolved_model_name() == ""
+
+    def test_openai_uses_explicit_values(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-key")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-4o")
+        settings = AISettings()
+        assert settings.resolved_base_url() == "https://api.openai.com/v1"
+        assert settings.resolved_model_name() == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# AISettings.is_configured
+# ---------------------------------------------------------------------------
+
+
+class TestIsConfigured:
+    """Tests for is_configured with provider presets."""
+
+    def test_minimax_configured_with_only_api_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        settings = AISettings()
+        assert settings.is_configured() is True
+
+    def test_openai_not_configured_without_url(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-key")
+        settings = AISettings()
+        assert settings.is_configured() is False
+
+    def test_openai_configured_with_url_and_model(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-key")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "gpt-4o")
+        settings = AISettings()
+        assert settings.is_configured() is True
+
+
+# ---------------------------------------------------------------------------
+# Provider presets registry
+# ---------------------------------------------------------------------------
+
+
+class TestProviderPresets:
+    """Tests for provider preset values."""
+
+    def test_minimax_preset_exists(self):
+        assert LLMProvider.MINIMAX in _PROVIDER_PRESETS
+
+    def test_minimax_preset_has_required_keys(self):
+        preset = _PROVIDER_PRESETS[LLMProvider.MINIMAX]
+        assert "base_url" in preset
+        assert "model_name" in preset
+
+    def test_minimax_base_url_value(self):
+        assert _PROVIDER_PRESETS[LLMProvider.MINIMAX]["base_url"] == "https://api.minimax.io/v1"
+
+    def test_minimax_default_model(self):
+        assert _PROVIDER_PRESETS[LLMProvider.MINIMAX]["model_name"] == "MiniMax-M2.7"
+
+
+# ---------------------------------------------------------------------------
+# AIClient initialization with MiniMax
+# ---------------------------------------------------------------------------
+
+
+class TestAIClientMiniMax:
+    """Tests for AIClient behavior with MiniMax provider."""
+
+    def test_client_initializes_with_minimax_settings(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-test-key")
+        client = AIClient()
+        assert client.is_available()
+        assert client.settings.resolve_provider() == LLMProvider.MINIMAX
+
+    def test_client_uses_resolved_model_in_call(self):
+        client = AIClient.__new__(AIClient)
+        client.settings = SimpleNamespace(
+            model_name="",
+            enable_response_format=True,
+            enable_thinking=False,
+            resolve_provider=lambda: LLMProvider.MINIMAX,
+            resolved_model_name=lambda: "MiniMax-M2.7",
+        )
+        request_history = []
+
+        async def fake_create(**kwargs):
+            request_history.append(kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content='{"ok":true}')
+                    )
+                ]
+            )
+
+        responses = SimpleNamespace(create=fake_create)
+        chat = SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        client.client = SimpleNamespace(responses=responses, chat=chat)
+
+        response = asyncio.run(client._call_ai([{"role": "user", "content": "test"}]))
+        assert response == '{"ok":true}'
+        assert request_history[0]["model"] == "MiniMax-M2.7"
+
+    def test_explicit_minimax_provider_with_custom_model(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "minimax")
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-test-key")
+        monkeypatch.setenv("OPENAI_MODEL_NAME", "MiniMax-M2.5-highspeed")
+        client = AIClient()
+        assert client.is_available()
+        assert client.settings.resolved_model_name() == "MiniMax-M2.5-highspeed"
+        assert client.settings.resolved_base_url() == "https://api.minimax.io/v1"
+
+
+# ---------------------------------------------------------------------------
+# LLMProvider enum
+# ---------------------------------------------------------------------------
+
+
+class TestLLMProviderEnum:
+    """Tests for LLMProvider enum values."""
+
+    def test_openai_value(self):
+        assert LLMProvider.OPENAI.value == "openai"
+
+    def test_minimax_value(self):
+        assert LLMProvider.MINIMAX.value == "minimax"
+
+    def test_from_string(self):
+        assert LLMProvider("minimax") == LLMProvider.MINIMAX
+        assert LLMProvider("openai") == LLMProvider.OPENAI


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com/) as a first-class LLM provider alongside existing OpenAI-compatible backends.

- **Zero-config setup**: users only need `MINIMAX_API_KEY` — base URL (`https://api.minimax.io/v1`) and default model (`MiniMax-M2.7`, supports Vision) are auto-configured
- **Provider auto-detection**: if `MINIMAX_API_KEY` is set and `OPENAI_API_KEY` is not, MiniMax is automatically selected. Users can also explicitly set `LLM_PROVIDER=minimax`
- **Full backward compatibility**: existing `OPENAI_*` env vars continue to work unchanged; the new `LLM_PROVIDER`, `MINIMAX_API_KEY` fields are all optional
- **Override support**: `OPENAI_BASE_URL` / `OPENAI_MODEL_NAME` can still override MiniMax defaults (e.g. for using `MiniMax-M2.5-highspeed`)

## Changes

| File | Change |
|------|--------|
| `src/infrastructure/config/settings.py` | Add `LLMProvider` enum, provider presets, and `resolve_provider()` / `resolved_api_key()` / `resolved_base_url()` / `resolved_model_name()` methods |
| `src/infrastructure/external/ai_client.py` | Use resolved settings for provider-aware client initialization |
| `src/config.py` | Legacy config now uses `AISettings` for provider detection |
| `.env.example` | Add MiniMax configuration examples and `LLM_PROVIDER` documentation |
| `README.md` / `README_EN.md` | Add MiniMax quick-start section and updated config table |
| `tests/unit/test_llm_provider.py` | 27 unit tests for provider detection, settings resolution, and client behavior |
| `tests/integration/test_minimax_provider.py` | 5 integration tests for end-to-end provider setup |
| `tests/unit/test_ai_client.py` | Fix 3 existing tests to work with new `resolved_model_name()` method |

## Test plan

- [x] All 93 tests pass (88 existing + 5 new integration)
- [x] 27 new unit tests cover: provider detection, API key resolution, base URL/model defaults, `is_configured()`, preset registry, AIClient MiniMax init, enum values
- [x] 5 integration tests cover: env-based auto-detection, explicit provider, custom model override, AIClient creation, legacy config compatibility
- [ ] Manual test: set only `MINIMAX_API_KEY` in `.env` and verify AI analysis works
