### PR TITLE
fix(web-ui): escape cron custom examples in i18n copy

### DIFF
--- a/web-ui/src/i18n/messages/en-US-extra.ts
+++ b/web-ui/src/i18n/messages/en-US-extra.ts
@@ -68,8 +68,8 @@ const enUSExtra = {
       cronPresetTab: 'Preset',
       cronCustomTab: 'Custom',
       cronPlaceholder: 'Select a schedule',
-      cronCustomPlaceholder: 'Example: 0 8 * * * / 0 0 8 * * * / @daily',
-      cronCustomHintLine1: 'Supports 5-part cron: minute hour day month weekday; 6-part cron with seconds; also supports @hourly / @daily / @weekly / @monthly / @yearly. Server timezone: Asia/Shanghai.',
+      cronCustomPlaceholder: 'Example: 0 8 * * * / 0 0 8 * * * / {\'@\'}daily',
+      cronCustomHintLine1: 'Supports 5-part cron: minute hour day month weekday; 6-part cron with seconds; also supports {\'@\'}hourly / {\'@\'}daily / {\'@\'}weekly / {\'@\'}monthly / {\'@\'}yearly. Server timezone: Asia/Shanghai.',
       cronCustomHintLine2: 'Examples: every 15 minutes */15 * * * *; every day at 8:00 0 8 * * *; every day at 8:00 with seconds 0 0 8 * * *.',
       cron: {
         manual: 'Manual Only',

--- a/web-ui/src/i18n/messages/zh-CN-extra.ts
+++ b/web-ui/src/i18n/messages/zh-CN-extra.ts
@@ -68,8 +68,8 @@ const zhCNExtra = {
       cronPresetTab: '预设',
       cronCustomTab: '自定义',
       cronPlaceholder: '选择定时规则',
-      cronCustomPlaceholder: '例如：0 8 * * * / 0 0 8 * * * / @daily',
-      cronCustomHintLine1: '支持 5 段：分 时 日 月 周；6 段：秒 分 时 日 月 周；也支持 @hourly / @daily / @weekly / @monthly / @yearly。服务端时区为 Asia/Shanghai。',
+      cronCustomPlaceholder: '例如：0 8 * * * / 0 0 8 * * * / {\'@\'}daily',
+      cronCustomHintLine1: '支持 5 段：分 时 日 月 周；6 段：秒 分 时 日 月 周；也支持 {\'@\'}hourly / {\'@\'}daily / {\'@\'}weekly / {\'@\'}monthly / {\'@\'}yearly。服务端时区为 Asia/Shanghai。',
       cronCustomHintLine2: '示例：每 15 分钟 */15 * * * *；每天 8 点 0 8 * * *；每天 8 点（带秒）0 0 8 * * *。',
       cron: {
         manual: '不定时（手动运行）',


### PR DESCRIPTION
## Summary
- escape literal @ cron aliases in task form i18n copy
- prevent vue-i18n from parsing @daily/@hourly as linked-message syntax
- restore the custom schedule input panel in the task form

## Testing
- reproduced the issue by opening the task form and clicking the custom cron tab
- verified the #cron input renders correctly after the fix in both Vite dev and the built app served on port 8001