### PR TITLE
fix(settings): scope channel test validation

### DIFF
--- a/src/api/routes/settings.py
+++ b/src/api/routes/settings.py
@@ -31,6 +31,7 @@ from src.services.notification_config_service import (
     build_notification_status_flags,
     load_notification_settings,
     model_dump,
+    prepare_notification_test_settings,
     prepare_notification_settings_update,
 )
 from src.services.notification_service import build_notification_service
@@ -147,15 +148,21 @@ async def update_notification_settings(settings: NotificationSettingsModel):
 @router.post("/notifications/test")
 async def test_notification_settings(payload: NotificationTestRequest):
     try:
-        _, _, merged_settings = prepare_notification_settings_update(
+        merged_settings = prepare_notification_test_settings(
             model_dump(payload.settings, exclude_unset=True),
             load_notification_settings(),
+            channel=payload.channel,
         )
     except NotificationSettingsValidationError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     service = build_notification_service(merged_settings)
     if not service.clients:
+        if payload.channel:
+            raise HTTPException(
+                status_code=422,
+                detail=f"渠道 {payload.channel} 未配置或不受支持",
+            )
         raise HTTPException(status_code=422, detail="请至少配置一个可用的通知渠道")
 
     results = await service.send_test_notification()

--- a/src/services/notification_config_service.py
+++ b/src/services/notification_config_service.py
@@ -29,6 +29,26 @@ NOTIFICATION_FIELD_MAP = {
     "PCURL_TO_MOBILE": "pcurl_to_mobile",
 }
 
+CHANNEL_NOTIFICATION_FIELDS = {
+    "ntfy": {"NTFY_TOPIC_URL"},
+    "bark": {"BARK_URL"},
+    "gotify": {"GOTIFY_URL", "GOTIFY_TOKEN"},
+    "wecom": {"WX_BOT_URL"},
+    "telegram": {
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_CHAT_ID",
+        "TELEGRAM_API_BASE_URL",
+    },
+    "webhook": {
+        "WEBHOOK_URL",
+        "WEBHOOK_METHOD",
+        "WEBHOOK_HEADERS",
+        "WEBHOOK_CONTENT_TYPE",
+        "WEBHOOK_QUERY_PARAMETERS",
+        "WEBHOOK_BODY",
+    },
+}
+
 SECRET_NOTIFICATION_FIELDS = {
     "BARK_URL",
     "GOTIFY_TOKEN",
@@ -169,11 +189,64 @@ def prepare_notification_settings_update(
     return updates, deletions, candidate_settings
 
 
+def prepare_notification_test_settings(
+    patch_payload: dict,
+    existing_settings: NotificationSettings | None = None,
+    *,
+    channel: str | None = None,
+) -> NotificationSettings:
+    if channel is None:
+        _, _, merged_settings = prepare_notification_settings_update(
+            patch_payload,
+            existing_settings,
+        )
+        return merged_settings
+
+    if channel not in CHANNEL_NOTIFICATION_FIELDS:
+        raise NotificationSettingsValidationError(f"不支持的通知渠道: {channel}")
+
+    current_settings = existing_settings or load_notification_settings()
+    included_env_fields = set(CHANNEL_NOTIFICATION_FIELDS[channel])
+    included_env_fields.add("PCURL_TO_MOBILE")
+    merged_values = _build_channel_test_values(current_settings, included_env_fields)
+
+    for env_name, raw_value in patch_payload.items():
+        if env_name not in included_env_fields:
+            continue
+        attr_name = NOTIFICATION_FIELD_MAP[env_name]
+        merged_values[attr_name] = _normalize_patch_value(env_name, raw_value)
+
+    normalized_values = _normalize_notification_values(merged_values)
+    candidate_settings = _build_notification_settings_model(normalized_values)
+    _validate_notification_settings(candidate_settings)
+    return candidate_settings
+
+
 def _notification_settings_to_values(settings: NotificationSettings) -> dict:
     return {
         attr_name: getattr(settings, attr_name)
         for attr_name in NOTIFICATION_FIELD_MAP.values()
     }
+
+
+def _build_channel_test_values(
+    settings: NotificationSettings,
+    included_env_fields: set[str],
+) -> dict:
+    values = {
+        attr_name: None
+        for attr_name in NOTIFICATION_FIELD_MAP.values()
+    }
+    values["telegram_api_base_url"] = DEFAULT_TELEGRAM_API_BASE_URL
+    values["webhook_method"] = "POST"
+    values["webhook_content_type"] = "JSON"
+    values["pcurl_to_mobile"] = True
+
+    for env_name in included_env_fields:
+        attr_name = NOTIFICATION_FIELD_MAP[env_name]
+        values[attr_name] = getattr(settings, attr_name)
+
+    return values
 
 
 def load_notification_settings() -> NotificationSettings:

--- a/tests/integration/test_api_settings.py
+++ b/tests/integration/test_api_settings.py
@@ -274,6 +274,53 @@ def test_notification_test_endpoint_merges_stored_secret_values(tmp_path, monkey
     assert captured["json"]["chat_id"] == "20002"
 
 
+def test_notification_test_endpoint_ignores_other_channel_dirty_fields(tmp_path, monkeypatch):
+    _clear_settings_env(monkeypatch)
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "NTFY_TOPIC_URL=https://ntfy.sh/demo-topic\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(env_manager, "env_file", env_file)
+    client = _build_settings_client()
+
+    captured = []
+
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+    def _fake_post(url, data=None, headers=None, timeout=None, **kwargs):
+        captured.append({
+            "url": url,
+            "data": data,
+            "headers": headers,
+        })
+        return _FakeResponse()
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    response = client.post(
+        "/api/settings/notifications/test",
+        json={
+            "channel": "ntfy",
+            "settings": {
+                "GOTIFY_URL": "not-a-url",
+                "WEBHOOK_BODY": '{"message":"{{content}}"}',
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert list(payload["results"]) == ["ntfy"]
+    assert payload["results"]["ntfy"]["success"] is True
+    assert len(captured) == 1
+    assert captured[0]["url"] == "https://ntfy.sh/demo-topic"
+
+
 def test_ai_settings_fall_back_to_runtime_environment_when_env_file_missing(tmp_path, monkeypatch):
     _clear_settings_env(monkeypatch)
     env_file = tmp_path / ".env"

--- a/web-ui/src/components/settings/NotificationSettingsPanel.vue
+++ b/web-ui/src/components/settings/NotificationSettingsPanel.vue
@@ -113,14 +113,24 @@ function clearChannel(channel: ChannelKey) {
 }
 
 function buildPayload(): NotificationSettingsUpdate {
+  return buildScopedPayload()
+}
+
+function buildScopedPayload(channel?: ChannelKey): NotificationSettingsUpdate {
   const payload: NotificationSettingsUpdate = {}
   const mutablePayload = payload as Record<string, string | boolean | null | undefined>
+  const includedFields = channel
+    ? new Set<string>([...channelFields[channel].map((field) => field as string), 'PCURL_TO_MOBILE'])
+    : null
   const textFields: (keyof NotificationSettingsUpdate)[] = [
     'NTFY_TOPIC_URL', 'GOTIFY_URL', 'TELEGRAM_CHAT_ID', 'TELEGRAM_API_BASE_URL', 'WEBHOOK_METHOD',
     'WEBHOOK_CONTENT_TYPE', 'WEBHOOK_QUERY_PARAMETERS', 'WEBHOOK_BODY',
   ]
 
   for (const field of textFields) {
+    if (includedFields && !includedFields.has(field as string)) {
+      continue
+    }
     if (mutableClearedFields[field as string]) {
       mutablePayload[field as string] = null
       continue
@@ -133,6 +143,9 @@ function buildPayload(): NotificationSettingsUpdate {
   }
 
   for (const field of secretFields) {
+    if (includedFields && !includedFields.has(field as string)) {
+      continue
+    }
     if (mutableClearedFields[field as string]) {
       mutablePayload[field as string] = null
       continue
@@ -143,7 +156,7 @@ function buildPayload(): NotificationSettingsUpdate {
     }
   }
 
-  if (form.PCURL_TO_MOBILE !== initialValues.PCURL_TO_MOBILE) {
+  if ((!includedFields || includedFields.has('PCURL_TO_MOBILE')) && form.PCURL_TO_MOBILE !== initialValues.PCURL_TO_MOBILE) {
     payload.PCURL_TO_MOBILE = !!form.PCURL_TO_MOBILE
   }
   return payload
@@ -160,7 +173,7 @@ async function handleSave() {
 async function handleTest(channel?: ChannelKey) {
   testingChannel.value = channel ?? 'all'
   try {
-    const response = await props.testSettings({ channel, settings: buildPayload() })
+    const response = await props.testSettings({ channel, settings: buildScopedPayload(channel) })
     Object.assign(testResults, response.results)
   } finally {
     testingChannel.value = null


### PR DESCRIPTION
## Summary
- scope notification channel test payloads and backend validation to the selected channel only
- keep `Test All` behavior unchanged while preventing unrelated dirty fields from blocking single-channel tests
- add integration coverage for testing ntfy with invalid unsaved gotify/webhook fields present

## Verification
- ./.venv/bin/pytest tests/integration/test_api_settings.py::test_notification_test_endpoint_merges_stored_secret_values tests/integration/test_api_settings.py::test_notification_test_endpoint_ignores_other_channel_dirty_fields tests/unit/test_notification_service.py
- cd web-ui && npm run build
