### PR TITLE
fix(ai-response-parser): 支持智谱 OpenAI 兼容网关的 reasoning_content 回退

### DIFF
--- a/src/services/ai_response_parser.py
+++ b/src/services/ai_response_parser.py
@@ -31,7 +31,15 @@ def extract_ai_response_content(response: Any) -> str:
         if message is None:
             raise EmptyAIResponseError("AI响应缺少 message。")
         content = getattr(message, "content", None)
-        return _normalize_text_content(_coerce_content_parts(content))
+        
+        # 智谱等 OpenAI 兼容网关在某些模式下会把输出放在 reasoning_content 而非 content
+        try:
+            return _normalize_text_content(_coerce_content_parts(content))
+        except EmptyAIResponseError:
+            reasoning_content = getattr(message, "reasoning_content", None)
+            if reasoning_content:
+                return _normalize_text_content(_coerce_content_parts(reasoning_content))
+            raise
 
     raise ValueError(f"无法识别的AI响应类型: {type(response).__name__}")
 

--- a/tests/unit/test_ai_response_parser.py
+++ b/tests/unit/test_ai_response_parser.py
@@ -1,6 +1,10 @@
 import pytest
 
-from src.services.ai_response_parser import parse_ai_response_json
+from src.services.ai_response_parser import (
+    extract_ai_response_content,
+    parse_ai_response_json,
+    EmptyAIResponseError,
+)
 
 
 def test_parse_ai_response_json_uses_first_object_when_multiple_json_objects_are_concatenated():
@@ -31,3 +35,32 @@ def test_parse_ai_response_json_extracts_json_from_wrapped_text():
 def test_parse_ai_response_json_raises_when_no_json_exists():
     with pytest.raises(ValueError):
         parse_ai_response_json("没有任何 JSON 内容")
+
+
+def test_extract_ai_response_content_with_none_content_but_valid_reasoning_content():
+    """当 content 为 None 但 reasoning_content 有值时，应该成功提取 reasoning_content 的内容"""
+    # 创建 mock 对象模拟 OpenAI 风格的响应
+    message = type('Message', (), {
+        'content': None,
+        'reasoning_content': '这是推理内容'
+    })()
+    choice = type('Choice', (), {'message': message})()
+    response = type('Response', (), {'choices': [choice]})()
+
+    result = extract_ai_response_content(response)
+
+    assert result == '这是推理内容'
+
+
+def test_extract_ai_response_content_raises_when_content_and_reasoning_content_are_empty():
+    """当 content 和 reasoning_content 都为空时，应该抛出 EmptyAIResponseError"""
+    # 创建 mock 对象
+    message = type('Message', (), {
+        'content': None,
+        'reasoning_content': None
+    })()
+    choice = type('Choice', (), {'message': message})()
+    response = type('Response', (), {'choices': [choice]})()
+
+    with pytest.raises(EmptyAIResponseError):
+        extract_ai_response_content(response)


### PR DESCRIPTION
发现智谱 AI 的 OpenAI 兼容网关在某些模式下会将响应内容放在 message.reasoning_content 而不是 message.content 字段中，导致解析失败。本修改添加了回退逻辑来处理这种情况，
同时保持与标准 OpenAI API 的向后兼容性。

- 更新 ai_response_parser 在 message.content 为空时回退读取 reasoning_content
- 修复了当智谱将响应内容放在 reasoning_content 字段时的解析失败问题
- 保持与标准 OpenAI API 的向后兼容性