### PR TITLE
fix(ai): work around httpx NO_PROXY IPv6 CIDR crash

### DIFF
--- a/src/infrastructure/external/ai_client.py
+++ b/src/infrastructure/external/ai_client.py
@@ -2,6 +2,7 @@
 AI 客户端封装
 提供统一的 AI 调用接口
 """
+import ipaddress
 import os
 import json
 import base64
@@ -33,6 +34,38 @@ from src.services.ai_response_parser import (
 )
 
 
+def _sanitize_no_proxy_env() -> None:
+    """Strip CIDR prefix lengths from IPv6 entries in NO_PROXY / no_proxy.
+
+    httpx <= 0.28.1 wraps NO_PROXY IPv6 entries in brackets *including* the
+    CIDR mask (e.g. ``[::1/128]``), which the URL parser rejects as an invalid
+    port.  Stripping the ``/prefix`` part is safe because httpx doesn't
+    support CIDR range matching anyway — it only does exact-host comparison.
+
+    See https://github.com/encode/httpx/pull/3741
+    """
+    for key in ("NO_PROXY", "no_proxy"):
+        value = os.environ.get(key)
+        if not value:
+            continue
+        parts = [h.strip() for h in value.split(",")]
+        cleaned: list[str] = []
+        changed = False
+        for part in parts:
+            if "/" in part:
+                host, _, prefix = part.partition("/")
+                try:
+                    ipaddress.IPv6Address(host)
+                    cleaned.append(host)
+                    changed = True
+                    continue
+                except ValueError:
+                    pass
+            cleaned.append(part)
+        if changed:
+            os.environ[key] = ",".join(cleaned)
+
+
 class AIClient:
     """AI 客户端封装"""
 
@@ -60,6 +93,8 @@ class AIClient:
                 print(f"正在为 AI 请求使用代理: {self.settings.proxy_url}")
                 os.environ['HTTP_PROXY'] = self.settings.proxy_url
                 os.environ['HTTPS_PROXY'] = self.settings.proxy_url
+
+            _sanitize_no_proxy_env()
 
             return AsyncOpenAI(
                 api_key=self.settings.api_key,

--- a/tests/unit/test_ai_client.py
+++ b/tests/unit/test_ai_client.py
@@ -1,9 +1,10 @@
 import asyncio
+import os
 from types import SimpleNamespace
 
 import pytest
 
-from src.infrastructure.external.ai_client import AIClient
+from src.infrastructure.external.ai_client import AIClient, _sanitize_no_proxy_env
 from src.services.ai_request_compat import build_responses_input
 
 
@@ -244,3 +245,38 @@ def test_parse_response_uses_first_json_object_when_response_contains_multiple_o
 ```""")
 
     assert result == {"ok": True, "reason": "first"}
+
+
+# -- _sanitize_no_proxy_env tests --
+
+
+def test_sanitize_no_proxy_strips_ipv6_cidr(monkeypatch):
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.0/8,::1/128")
+    _sanitize_no_proxy_env()
+    assert os.environ["NO_PROXY"] == "localhost,127.0.0.0/8,::1"
+
+
+def test_sanitize_no_proxy_strips_lowercase_variant(monkeypatch):
+    monkeypatch.setenv("no_proxy", "localhost,::1/128,fe80::1/64")
+    _sanitize_no_proxy_env()
+    assert os.environ["no_proxy"] == "localhost,::1,fe80::1"
+
+
+def test_sanitize_no_proxy_preserves_ipv4_cidr(monkeypatch):
+    monkeypatch.setenv("NO_PROXY", "10.0.0.0/8,192.168.0.0/16")
+    _sanitize_no_proxy_env()
+    assert os.environ["NO_PROXY"] == "10.0.0.0/8,192.168.0.0/16"
+
+
+def test_sanitize_no_proxy_noop_without_env(monkeypatch):
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    _sanitize_no_proxy_env()
+
+
+def test_sanitize_no_proxy_handles_both_keys(monkeypatch):
+    monkeypatch.setenv("NO_PROXY", "::1/128")
+    monkeypatch.setenv("no_proxy", "fe80::1/10")
+    _sanitize_no_proxy_env()
+    assert os.environ["NO_PROXY"] == "::1"
+    assert os.environ["no_proxy"] == "fe80::1"


### PR DESCRIPTION
## Problem

OrbStack / Docker Desktop automatically injects proxy environment variables into containers:

```
NO_PROXY=localhost,127.0.0.0/8,::1/128
```

httpx <= 0.28.1's `get_environment_proxies()` wraps IPv6 CIDR entries from `NO_PROXY` inside brackets including the CIDR mask (e.g. `all://[::1/128]`), causing the URL parser to misinterpret `/128` as a port and throw `Invalid port: ':1'`.

This crashes `AsyncOpenAI` client initialization, making AI analysis completely unavailable.

## Root Cause

In httpx `_utils.get_environment_proxies()`:

```python
elif is_ipv6_hostname(hostname):           # "::1/128" -> True
    mounts[f"all://[{hostname}]"] = None   # -> "all://[::1/128]"
```

`is_ipv6_hostname` correctly identifies IPv6 via `split("/")[0]`, but the URL construction includes the CIDR mask inside brackets. `URLPattern` then parses `[::1/128]` and treats `/128]` as part of the authority, ultimately failing on `int(":1")`.

Upstream fix PR ([encode/httpx#3741](https://github.com/encode/httpx/pull/3741)) has passing CI but remains unmerged. httpx has not released for over 16 months.

## Fix

Call `_sanitize_no_proxy_env()` before creating `AsyncOpenAI` in `AIClient._initialize_client`. This strips CIDR prefix lengths from IPv6 entries in `NO_PROXY` / `no_proxy` (e.g. `::1/128` -> `::1`).

- IPv4 CIDR entries (e.g. `10.0.0.0/8`) are preserved
- No functional loss: httpx 0.28.1 doesn't support CIDR range matching anyway
- Once httpx merges the upstream fix, this workaround becomes a harmless no-op

## Tests

5 new unit tests covering: IPv6 CIDR stripping, case variants (`NO_PROXY` / `no_proxy`), IPv4 CIDR preservation, missing env vars, and both keys present simultaneously.

Verified in container: `AIClient` initializes successfully with `NO_PROXY=localhost,127.0.0.0/8,::1/128`.