### PR TITLE
fix(ai): detect response_format rejection from AI gateways

### DIFF
--- a/src/services/ai_request_compat.py
+++ b/src/services/ai_request_compat.py
@@ -76,7 +76,14 @@ def add_json_response_format(
 
 
 def is_json_output_unsupported_error(error: Exception) -> bool:
-    """识别模型不支持结构化 JSON 输出参数的错误。"""
+    """识别模型或网关不支持结构化 JSON 输出参数的错误。"""
+    body = getattr(error, "body", None)
+    if isinstance(body, dict) and body.get("param") in (
+        "response_format",
+        "response_format.type",
+    ):
+        return True
+
     message = str(error)
     return (
         "not supported" in message.lower()

--- a/tests/unit/test_ai_request_compat.py
+++ b/tests/unit/test_ai_request_compat.py
@@ -1,4 +1,5 @@
 from src.services.ai_request_compat import (
+    is_json_output_unsupported_error,
     is_responses_api_unsupported_error,
     is_temperature_unsupported_error,
     remove_temperature_param,
@@ -32,3 +33,52 @@ def test_is_responses_api_unsupported_error_detects_gemini_plain_404():
             return "Error code: 404"
 
     assert is_responses_api_unsupported_error(_Err()) is True
+
+
+# -- is_json_output_unsupported_error tests --
+
+
+def test_json_output_error_detected_via_body_param_response_format():
+    """Vercel AI Gateway returns 400 with param='response_format'."""
+
+    class _Err(Exception):
+        body = {
+            "message": "Invalid input",
+            "type": "invalid_request_error",
+            "param": "response_format",
+            "code": "invalid_request_error",
+        }
+
+    assert is_json_output_unsupported_error(_Err()) is True
+
+
+def test_json_output_error_detected_via_body_param_response_format_type():
+    class _Err(Exception):
+        body = {
+            "message": "Invalid input",
+            "param": "response_format.type",
+        }
+
+    assert is_json_output_unsupported_error(_Err()) is True
+
+
+def test_json_output_error_detected_via_legacy_string_matching():
+    err = Exception(
+        "response_format.type is not supported by this model"
+    )
+    assert is_json_output_unsupported_error(err) is True
+
+
+def test_json_output_error_not_triggered_by_unrelated_400():
+    class _Err(Exception):
+        body = {
+            "message": "Invalid input",
+            "param": "messages",
+        }
+
+    assert is_json_output_unsupported_error(_Err()) is False
+
+
+def test_json_output_error_not_triggered_without_body():
+    err = Exception("some random 400 error")
+    assert is_json_output_unsupported_error(err) is False


### PR DESCRIPTION
## Problem

Some AI gateways (e.g. Vercel AI Gateway) reject the legacy Chat Completions `response_format: {"type": "json_object"}` parameter with a 400 error:

```json
{"error": {"message": "Invalid input", "type": "invalid_request_error", "param": "response_format", "code": "invalid_request_error"}}
```

The existing fallback logic in `is_json_output_unsupported_error()` only matches errors containing `"not supported"` in the message text. Since the gateway returns `"Invalid input"` instead, the detection never triggers and all 4 retry attempts fail with the same 400 — `response_format` is never disabled.

## Fix

Check the structured `error.body.param` field (set by the openai SDK on `BadRequestError`) in addition to the existing string-matching heuristic:

```python
body = getattr(error, "body", None)
if isinstance(body, dict) and body.get("param") in (
    "response_format",
    "response_format.type",
):
    return True
```

This is more precise than adding more string markers — it directly inspects the structured error payload without risk of false positives on unrelated 400 errors.

After the fix, the retry loop correctly disables `response_format` on the next attempt and the AI call succeeds.

## Tests

5 new unit tests covering:
- Gateway-style error with `param: "response_format"` (detected)
- Gateway-style error with `param: "response_format.type"` (detected)
- Legacy string matching still works (backward compat)
- Unrelated 400 with `param: "messages"` (not falsely matched)
- Plain exception without `body` attribute (not falsely matched)