### PR TITLE
fix(web-ui): allow selecting province/city when it has no children re…

### DIFF
--- a/web-ui/src/components/tasks/TaskRegionSelector.vue
+++ b/web-ui/src/components/tasks/TaskRegionSelector.vue
@@ -126,7 +126,7 @@ watch(() => props.modelValue, syncFromModel, { immediate: true })
       </Select>
 
       <Select
-        :disabled="!selectedProvince || cityOptions.length === 0"
+        :disabled="!selectedProvince || (cityOptions.length === 0 && selectedProvince !== '全国')"
         :model-value="selectedCity"
         @update:model-value="(value) => handleCityChange(String(value || ''))"
       >
@@ -141,7 +141,7 @@ watch(() => props.modelValue, syncFromModel, { immediate: true })
       </Select>
 
       <Select
-        :disabled="!selectedCity || districtOptions.length === 0"
+        :disabled="!selectedCity || (districtOptions.length === 0 && !isFullOption(selectedCity))"
         :model-value="selectedDistrict"
         @update:model-value="(value) => handleDistrictChange(String(value || ''))"
       >


### PR DESCRIPTION
…gions (e.g. 广东省)

Fixes an issue where '广东省' could not be selected because its city options include '全广东' which has an empty array of districts, causing the city select or district select to be erroneously disabled if length is 0. Now the select is only disabled if there are 0 options AND it's not a special '全' or '全国' option that is meant to be selected by itself.