### PR TITLE
feat: add item block/unblock and persist filter selections

### DIFF
--- a/src/api/routes/results.py
+++ b/src/api/routes/results.py
@@ -3,6 +3,9 @@
 """
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import Response
+from enum import Enum
+
+from pydantic import BaseModel
 from urllib.parse import quote
 
 from src.services.price_history_service import build_price_history_insights
@@ -18,6 +21,7 @@ from src.services.result_storage_service import (
     load_all_result_records,
     query_result_records,
     result_file_exists,
+    update_item_status,
 )
 
 
@@ -163,3 +167,26 @@ async def export_result_file_content(
     export_name = filename.replace(".jsonl", ".csv")
     headers = _build_download_headers(export_name)
     return Response(content=csv_text, media_type="text/csv; charset=utf-8", headers=headers)
+
+
+class ItemStatus(str, Enum):
+    ACTIVE = "active"
+    HIDDEN = "hidden"
+    EXPIRED = "expired"
+
+
+class UpdateStatusRequest(BaseModel):
+    status: ItemStatus
+
+
+@router.patch("/{filename}/items/{item_id}/status")
+async def patch_item_status(filename: str, item_id: str, body: UpdateStatusRequest):
+    """更新指定商品的状态（active/hidden/expired）"""
+    try:
+        validate_result_filename(filename)
+        updated = await update_item_status(filename, item_id, body.status.value)
+        if not updated:
+            raise HTTPException(status_code=404, detail="商品未找到")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"message": "状态已更新", "status": body.status.value}

--- a/src/infrastructure/persistence/sqlite_connection.py
+++ b/src/infrastructure/persistence/sqlite_connection.py
@@ -64,6 +64,7 @@ SCHEMA_STATEMENTS = (
         is_recommended INTEGER NOT NULL,
         analysis_source TEXT,
         keyword_hit_count INTEGER NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
         raw_json TEXT NOT NULL,
         UNIQUE(result_filename, link_unique_key)
     )
@@ -134,7 +135,29 @@ def _apply_pragmas(conn: sqlite3.Connection) -> None:
 def init_schema(conn: sqlite3.Connection) -> None:
     for statement in SCHEMA_STATEMENTS:
         conn.execute(statement)
+    _migrate_result_items_status(conn)
     conn.commit()
+
+
+def _migrate_result_items_status(conn: sqlite3.Connection) -> None:
+    """为 result_items 表添加 status 列（仅执行一次）。"""
+    row = conn.execute(
+        "SELECT value FROM app_metadata WHERE key = 'migration:result_items_status'"
+    ).fetchone()
+    if row is not None:
+        return
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(result_items)").fetchall()]
+    if "status" not in cols:
+        conn.execute(
+            "ALTER TABLE result_items ADD COLUMN status TEXT NOT NULL DEFAULT 'active'"
+        )
+    conn.execute(
+        "INSERT OR REPLACE INTO app_metadata(key, value) VALUES ('migration:result_items_status', 'done')"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_results_filename_status_crawl"
+        " ON result_items(result_filename, status, crawl_time DESC)"
+    )
 
 
 @contextmanager

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -25,6 +25,8 @@ async def _parse_search_results_json(json_data: dict, source: str) -> list:
             title = await safe_get(main_data, "title", default="未知标题")
             price_parts = await safe_get(main_data, "price", default=[])
             price = "".join([str(p.get("text", "")) for p in price_parts if isinstance(p, dict)]).replace("当前价", "").strip() if isinstance(price_parts, list) else "价格异常"
+            # 确保price是字符串类型，避免float类型导致的"in"操作错误
+            price = str(price) if not isinstance(price, str) else price
             if "万" in price: price = f"¥{float(price.replace('¥', '').replace('万', '')) * 10000:.0f}"
             area = await safe_get(main_data, "area", default="地区未知")
             seller = await safe_get(main_data, "userNickName", default="匿名卖家")

--- a/src/services/result_storage_service.py
+++ b/src/services/result_storage_service.py
@@ -35,8 +35,11 @@ def _fallback_unique_key(record: dict, item: dict) -> str:
     return f"hash:{digest}"
 
 
-def _parse_raw_record(raw_json: str) -> dict:
-    return json.loads(raw_json)
+def _parse_raw_record(raw_json: str, *, status: str | None = None) -> dict:
+    record = json.loads(raw_json)
+    if status is not None:
+        record["_status"] = status
+    return record
 
 
 def _build_query_conditions(
@@ -51,17 +54,19 @@ def _build_query_conditions(
         conditions.append("is_recommended = 1")
         conditions.append("analysis_source = ?")
         params.append("ai")
+        conditions.append("status = 'active'")
     if keyword_recommended_only:
         conditions.append("is_recommended = 1")
         conditions.append("analysis_source = ?")
         params.append("keyword")
+        conditions.append("status = 'active'")
     return " AND ".join(conditions), params
 
 
 def _sort_expression(sort_by: str, sort_order: str) -> str:
     column = SORT_COLUMN_MAP.get(sort_by, SORT_COLUMN_MAP["crawl_time"])
     direction = "ASC" if sort_order == "asc" else "DESC"
-    return f"{column} {direction}, id {direction}"
+    return f"(CASE WHEN status = 'active' THEN 0 ELSE 1 END), {column} {direction}, id {direction}"
 
 
 async def save_result_record(record: dict, keyword: str) -> bool:
@@ -216,7 +221,7 @@ def _query_result_records_sync(
         ).fetchone()
         rows = conn.execute(
             f"""
-            SELECT raw_json
+            SELECT raw_json, status
             FROM result_items
             WHERE {where_clause}
             ORDER BY {order_clause}
@@ -225,7 +230,7 @@ def _query_result_records_sync(
             tuple(params + [limit, offset]),
         ).fetchall()
     total = int(total_row["total"]) if total_row else 0
-    return total, [_parse_raw_record(str(row["raw_json"])) for row in rows]
+    return total, [_parse_raw_record(str(row["raw_json"]), status=row["status"]) for row in rows]
 
 
 async def load_all_result_records(
@@ -263,25 +268,28 @@ def _load_all_result_records_sync(
     with sqlite_connection() as conn:
         rows = conn.execute(
             f"""
-            SELECT raw_json
+            SELECT raw_json, status
             FROM result_items
             WHERE {where_clause}
             ORDER BY {order_clause}
             """,
             tuple(params),
         ).fetchall()
-    return [_parse_raw_record(str(row["raw_json"])) for row in rows]
+    return [_parse_raw_record(str(row["raw_json"]), status=row["status"]) for row in rows]
 
 
 async def build_result_ndjson(filename: str) -> str:
-    records = await load_all_result_records(
-        filename,
-        ai_recommended_only=False,
-        keyword_recommended_only=False,
-        sort_by="crawl_time",
-        sort_order="asc",
-    )
-    return "\n".join(json.dumps(record, ensure_ascii=False) for record in records)
+    return await asyncio.to_thread(_build_result_ndjson_sync, filename)
+
+
+def _build_result_ndjson_sync(filename: str) -> str:
+    bootstrap_sqlite_storage()
+    with sqlite_connection() as conn:
+        rows = conn.execute(
+            "SELECT raw_json FROM result_items WHERE result_filename = ? ORDER BY id ASC",
+            (filename,),
+        ).fetchall()
+    return "\n".join(str(row["raw_json"]) for row in rows)
 
 
 async def load_result_summary(filename: str) -> dict | None:
@@ -295,9 +303,9 @@ def _load_result_summary_sync(filename: str) -> dict | None:
             """
             SELECT
                 COUNT(1) AS total_items,
-                SUM(CASE WHEN is_recommended = 1 THEN 1 ELSE 0 END) AS recommended_items,
-                SUM(CASE WHEN is_recommended = 1 AND analysis_source = 'ai' THEN 1 ELSE 0 END) AS ai_recommended_items,
-                SUM(CASE WHEN is_recommended = 1 AND analysis_source = 'keyword' THEN 1 ELSE 0 END) AS keyword_recommended_items,
+                SUM(CASE WHEN is_recommended = 1 AND status = 'active' THEN 1 ELSE 0 END) AS recommended_items,
+                SUM(CASE WHEN is_recommended = 1 AND analysis_source = 'ai' AND status = 'active' THEN 1 ELSE 0 END) AS ai_recommended_items,
+                SUM(CASE WHEN is_recommended = 1 AND analysis_source = 'keyword' AND status = 'active' THEN 1 ELSE 0 END) AS keyword_recommended_items,
                 MAX(crawl_time) AS latest_crawl_time
             FROM result_items
             WHERE result_filename = ?
@@ -309,7 +317,7 @@ def _load_result_summary_sync(filename: str) -> dict | None:
 
         latest_record = conn.execute(
             """
-            SELECT raw_json FROM result_items
+            SELECT raw_json, status FROM result_items
             WHERE result_filename = ?
             ORDER BY crawl_time DESC, id DESC
             LIMIT 1
@@ -318,8 +326,8 @@ def _load_result_summary_sync(filename: str) -> dict | None:
         ).fetchone()
         latest_recommendation = conn.execute(
             """
-            SELECT raw_json FROM result_items
-            WHERE result_filename = ? AND is_recommended = 1
+            SELECT raw_json, status FROM result_items
+            WHERE result_filename = ? AND is_recommended = 1 AND status = 'active'
             ORDER BY crawl_time DESC, id DESC
             LIMIT 1
             """,
@@ -332,11 +340,29 @@ def _load_result_summary_sync(filename: str) -> dict | None:
         "keyword_recommended_items": int(aggregate_row["keyword_recommended_items"] or 0),
         "latest_crawl_time": aggregate_row["latest_crawl_time"],
         "latest_record": (
-            _parse_raw_record(str(latest_record["raw_json"])) if latest_record else None
+            _parse_raw_record(str(latest_record["raw_json"]), status=latest_record["status"]) if latest_record else None
         ),
         "latest_recommendation": (
-            _parse_raw_record(str(latest_recommendation["raw_json"]))
+            _parse_raw_record(str(latest_recommendation["raw_json"]), status=latest_recommendation["status"])
             if latest_recommendation
             else None
         ),
     }
+
+
+async def update_item_status(filename: str, item_id: str, status: str) -> bool:
+    valid = {"active", "hidden", "expired"}
+    if status not in valid:
+        raise ValueError(f"status must be one of {valid}")
+    return await asyncio.to_thread(_update_item_status_sync, filename, item_id, status)
+
+
+def _update_item_status_sync(filename: str, item_id: str, status: str) -> bool:
+    bootstrap_sqlite_storage()
+    with sqlite_connection() as conn:
+        cursor = conn.execute(
+            "UPDATE result_items SET status = ? WHERE result_filename = ? AND item_id = ?",
+            (status, filename, item_id),
+        )
+        conn.commit()
+        return cursor.rowcount > 0

--- a/web-ui/src/api/results.ts
+++ b/web-ui/src/api/results.ts
@@ -51,3 +51,11 @@ export function downloadResultExport(filename: string, params: GetResultContentP
   link.click()
   document.body.removeChild(link)
 }
+
+export async function updateItemStatus(filename: string, itemId: string, status: string): Promise<{ message: string; status: string }> {
+  return await http(`/api/results/${filename}/items/${itemId}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  })
+}

--- a/web-ui/src/components/results/ResultCard.vue
+++ b/web-ui/src/components/results/ResultCard.vue
@@ -10,7 +10,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import Badge from '@/components/ui/badge/Badge.vue'
-import { ExternalLink, TrendingUp, TrendingDown, Info, User, Clock, CheckCircle2, XCircle, AlertCircle } from 'lucide-vue-next'
+import { ExternalLink, TrendingUp, TrendingDown, Info, User, Clock, CheckCircle2, XCircle, AlertCircle, EyeOff, Eye } from 'lucide-vue-next'
 import { formatDateTime } from '@/i18n'
 
 interface Props {
@@ -18,6 +18,9 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'toggle-block', item: ResultItem): void
+}>()
 const { t } = useI18n()
 
 const info = props.item.商品信息
@@ -37,12 +40,13 @@ const crawlTime = props.item.爬取时间
   ? formatDateTime(props.item.爬取时间, { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
   : t('common.unknown')
 const matchScore = ai?.value_score ?? 0
+const isHidden = computed(() => props.item._status === 'hidden')
 
 const expanded = ref(false)
 </script>
 
 <template>
-  <Card class="group flex flex-col h-full border-none shadow-glass hover:shadow-card-hover transition-all duration-300 rounded-2xl overflow-hidden bg-white/80 backdrop-blur-sm">
+  <Card class="group flex flex-col h-full border-none shadow-glass hover:shadow-card-hover transition-all duration-300 rounded-2xl overflow-hidden bg-white/80 backdrop-blur-sm" :class="{ 'opacity-50': isHidden }">
     <!-- Image Header -->
     <div class="relative aspect-[4/3] overflow-hidden">
       <div class="absolute inset-0 bg-slate-200 animate-pulse" v-if="!imageUrl"></div>
@@ -53,13 +57,26 @@ const expanded = ref(false)
         class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
         loading="lazy"
       />
+      <!-- Hidden overlay -->
+      <div v-if="isHidden" class="absolute inset-0 bg-black/30 flex items-center justify-center">
+        <span class="text-white/80 text-xs font-semibold uppercase tracking-wider">{{ t('results.card.hidden') }}</span>
+      </div>
       <!-- Overlays -->
       <div class="absolute top-3 left-3 flex gap-2">
-        <Badge v-if="isRecommended" variant="default" class="bg-emerald-500/90 backdrop-blur-md border-none shadow-sm">
+        <Badge v-if="isRecommended && !isHidden" variant="default" class="bg-emerald-500/90 backdrop-blur-md border-none shadow-sm">
           {{ t('results.card.curated') }}
         </Badge>
       </div>
-      <div class="absolute top-3 right-3">
+      <div class="absolute top-3 right-3 flex gap-1.5">
+        <button
+          type="button"
+          @click="emit('toggle-block', props.item)"
+          :aria-label="isHidden ? t('results.card.unblock') : t('results.card.block')"
+          class="flex rounded-full bg-white/30 p-1.5 text-white backdrop-blur-md border border-white/40 shadow-sm opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 hover:bg-white/50"
+        >
+          <EyeOff v-if="!isHidden" class="w-4 h-4" />
+          <Eye v-else class="w-4 h-4" />
+        </button>
          <a
            :href="info.商品链接"
            target="_blank"

--- a/web-ui/src/components/results/ResultsGrid.vue
+++ b/web-ui/src/components/results/ResultsGrid.vue
@@ -10,6 +10,10 @@ interface Props {
 
 defineProps<Props>()
 const { t } = useI18n()
+
+const emit = defineEmits<{
+  (e: 'toggle-block', item: ResultItem): void
+}>()
 const skeletonItems = Array.from({ length: 8 }, (_, index) => index)
 </script>
 
@@ -42,7 +46,7 @@ const skeletonItems = Array.from({ length: 8 }, (_, index) => index)
       {{ t('results.grid.empty') }}
     </div>
     <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-      <ResultCard v-for="item in results" :key="item.商品信息.商品ID" :item="item" />
+      <ResultCard v-for="item in results" :key="item.商品信息.商品ID" :item="item" @toggle-block="emit('toggle-block', $event)" />
     </div>
   </div>
 </template>

--- a/web-ui/src/composables/useResults.ts
+++ b/web-ui/src/composables/useResults.ts
@@ -25,13 +25,24 @@ export function useResults() {
   const readyDelayMs = 200
   let readyTimer: ReturnType<typeof setTimeout> | null = null
   
-  const filters = reactive<Required<Omit<GetResultContentParams, 'page' | 'limit'>>>({
-    recommended_only: false,
-    ai_recommended_only: false,
-    keyword_recommended_only: false,
-    sort_by: 'crawl_time',
-    sort_order: 'desc',
-  })
+  const STORAGE_KEY_FILTERS = 'resultFilters'
+
+  function loadPersistedFilters(): Required<Omit<GetResultContentParams, 'page' | 'limit'>> {
+    const defaults: Required<Omit<GetResultContentParams, 'page' | 'limit'>> = {
+      recommended_only: false,
+      ai_recommended_only: false,
+      keyword_recommended_only: false,
+      sort_by: 'crawl_time',
+      sort_order: 'desc',
+    }
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY_FILTERS)
+      if (saved) return { ...defaults, ...JSON.parse(saved) }
+    } catch { /* ignore */ }
+    return defaults
+  }
+
+  const filters = reactive<Required<Omit<GetResultContentParams, 'page' | 'limit'>>>(loadPersistedFilters())
 
   const isLoading = ref(false)
   const error = ref<Error | null>(null)
@@ -190,7 +201,23 @@ export function useResults() {
     }
   }
 
+  async function toggleItemBlock(item: ResultItem) {
+    if (!selectedFile.value) return
+    const itemId = item.商品信息?.商品ID
+    if (!itemId) return
+    const newStatus = item._status === 'hidden' ? 'active' : 'hidden'
+    try {
+      await resultsApi.updateItemStatus(selectedFile.value, itemId, newStatus)
+      await fetchResults()
+    } catch (e) {
+      if (e instanceof Error) error.value = e
+    }
+  }
+
   // Watchers
+  watch(filters, (val) => {
+    localStorage.setItem(STORAGE_KEY_FILTERS, JSON.stringify(val))
+  }, { deep: true })
   watch([selectedFile, filters], fetchResults, { deep: true })
   watch(selectedFile, () => {
     fetchInsights()
@@ -242,6 +269,7 @@ export function useResults() {
     refreshResults,
     exportSelectedResults,
     deleteSelectedFile,
+    toggleItemBlock,
     fileOptions,
     isFileOptionsReady,
   }

--- a/web-ui/src/i18n/messages/en-US.ts
+++ b/web-ui/src/i18n/messages/en-US.ts
@@ -199,6 +199,9 @@ const enUS = {
       historicalLow: 'Historical Low',
       anonymous: 'Anonymous',
       detail: 'Open',
+      hidden: 'Hidden',
+      block: 'Block',
+      unblock: 'Unblock',
     },
   },
   logs: {

--- a/web-ui/src/i18n/messages/zh-CN.ts
+++ b/web-ui/src/i18n/messages/zh-CN.ts
@@ -199,6 +199,9 @@ const zhCN = {
       historicalLow: '历史低位',
       anonymous: '匿名',
       detail: '详情',
+      hidden: '已屏蔽',
+      block: '屏蔽',
+      unblock: '取消屏蔽',
     },
   },
   logs: {

--- a/web-ui/src/types/result.d.ts
+++ b/web-ui/src/types/result.d.ts
@@ -101,4 +101,5 @@ export interface ResultItem {
   "卖家信息": SellerInfo;
   ai_analysis: AiAnalysis;
   price_insight?: PriceInsight;
+  _status?: 'active' | 'hidden' | 'expired';
 }

--- a/web-ui/src/views/ResultsView.vue
+++ b/web-ui/src/views/ResultsView.vue
@@ -29,6 +29,7 @@ const {
   refreshResults,
   exportSelectedResults,
   deleteSelectedFile,
+  toggleItemBlock,
   fileOptions,
   isFileOptionsReady,
 } = useResults()
@@ -115,7 +116,7 @@ async function handleDeleteResults() {
 
     <ResultsInsightsPanel :insights="insights" :selected-task-label="selectedTaskLabel" />
 
-    <ResultsGrid :results="results" :is-loading="isLoading" />
+    <ResultsGrid :results="results" :is-loading="isLoading" @toggle-block="toggleItemBlock" />
 
     <Dialog v-model:open="isDeleteDialogOpen">
       <DialogContent class="sm:max-w-[420px]">


### PR DESCRIPTION
## Summary

- **手动屏蔽/解除屏蔽**：结果卡片新增屏蔽按钮，屏蔽的商品排在列表末尾，且在 AI/关键词推荐筛选中自动排除
- **过滤器状态持久化**：用户选择的排序方式、AI 推荐/关键词推荐过滤条件保存到浏览器 localStorage，刷新页面后保持
- **parsers.py 修复**：修复价格字段为 float 类型时 `"万" in price` 的 TypeError

## Changes

### 后端
- `sqlite_connection.py`：新增 `result_items.status` 列迁移（active/hidden/expired）
- `result_storage_service.py`：查询条件排除非 active 记录，排序时 active 优先；新增 `update_item_status` 方法
- `results.py`：新增 `PATCH /{filename}/items/{item_id}/status` API

### 前端
- `ResultCard.vue`：添加屏蔽/解除屏蔽按钮，屏蔽状态半透明遮罩
- `ResultsGrid.vue`：传递 toggle-block 事件
- `ResultsView.vue`：连接事件到 composable
- `useResults.ts`：新增 `toggleItemBlock` 方法 + 过滤器 localStorage 持久化
- `result.d.ts`：新增 `_status` 字段
- `api/results.ts`：新增 `updateItemStatus` API 调用
- i18n 中英文新增屏蔽相关翻译

### Bug fix
- `parsers.py`：价格解析时增加 float→str 类型转换，避免 `argument of type 'float' is not iterable`

## Test plan

- [ ] 打开结果页面，点击卡片上的屏蔽按钮，验证商品变灰并排到最后
- [ ] 切换"仅看AI推荐"/"仅看关键词推荐"，验证被屏蔽商品不出现在列表
- [ ] 再次点击取消屏蔽，验证恢复正常
- [ ] 刷新页面后验证过滤器选项（排序、推荐筛选）保持不变
- [ ] 重启服务后验证 SQLite 迁移正常执行，已有数据不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)